### PR TITLE
Add emoji scoring and counts to PR cards

### DIFF
--- a/src/components/PRCard.tsx
+++ b/src/components/PRCard.tsx
@@ -1,4 +1,5 @@
 import type { PullRequest } from "@/lib/github";
+import { EMOJI_MAP_EXPORTED } from "@/lib/github";
 
 interface PRCardProps {
   pr: PullRequest;
@@ -6,6 +7,39 @@ interface PRCardProps {
 }
 
 export function PRCard({ pr, rank }: PRCardProps) {
+  // Separate emojis into positive and negative
+  const positiveEmojis = Object.entries(pr.emojiCounts)
+    .filter(([_, count]) => count > 0)
+    .map(([key, count]) => ({
+      key,
+      emoji: EMOJI_MAP_EXPORTED[key]?.emoji || "",
+      score: EMOJI_MAP_EXPORTED[key]?.score || 0,
+      count,
+    }))
+    .filter(({ score }) => score > 0);
+
+  const negativeEmojis = Object.entries(pr.emojiCounts)
+    .filter(([_, count]) => count > 0)
+    .map(([key, count]) => ({
+      key,
+      emoji: EMOJI_MAP_EXPORTED[key]?.emoji || "",
+      score: EMOJI_MAP_EXPORTED[key]?.score || 0,
+      count,
+    }))
+    .filter(({ score }) => score < 0);
+
+  const neutralEmojis = Object.entries(pr.emojiCounts)
+    .filter(([_, count]) => count > 0)
+    .map(([key, count]) => ({
+      key,
+      emoji: EMOJI_MAP_EXPORTED[key]?.emoji || "",
+      score: EMOJI_MAP_EXPORTED[key]?.score || 0,
+      count,
+    }))
+    .filter(({ score }) => score === 0);
+
+  const hasAnyEmojis = positiveEmojis.length > 0 || negativeEmojis.length > 0 || neutralEmojis.length > 0;
+
   return (
     <a
       href={pr.url}
@@ -13,8 +47,8 @@ export function PRCard({ pr, rank }: PRCardProps) {
       rel="noopener noreferrer"
       className="block w-full p-4 rounded-lg border border-zinc-200 hover:border-zinc-400 transition-colors"
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1 min-w-0">
+      <div className="flex items-stretch justify-between gap-4">
+        <div className="flex-1 min-w-0 flex flex-col">
           <div className="flex items-center gap-2">
             <span className="text-zinc-500 text-sm">#{pr.number}</span>
             {rank === 1 && (
@@ -26,9 +60,48 @@ export function PRCard({ pr, rank }: PRCardProps) {
           <h3 className="mt-1 font-medium truncate">{pr.title}</h3>
           <p className="mt-1 text-sm text-zinc-500">by @{pr.author}</p>
         </div>
-        <div className="flex items-center gap-1.5 text-lg font-medium">
-          <span>👍</span>
-          <span>{pr.votes}</span>
+        <div className="flex flex-col items-end justify-end gap-1">
+          {hasAnyEmojis && (
+            <>
+              {positiveEmojis.length > 0 && (
+                <div className="flex items-center gap-1.5 text-lg font-medium">
+                  {positiveEmojis.map(({ emoji, count, key }) => (
+                    <div key={key} className="flex items-center gap-1">
+                      <span>{emoji}</span>
+                      <span>{count}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {negativeEmojis.length > 0 && (
+                <div className="flex items-center gap-1.5 text-lg font-medium">
+                  {negativeEmojis.map(({ emoji, count, key }) => (
+                    <div key={key} className="flex items-center gap-1">
+                      <span>{emoji}</span>
+                      <span>{count}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {neutralEmojis.length > 0 && (
+                <div className="flex items-center gap-1.5 text-lg font-medium">
+                  {neutralEmojis.map(({ emoji, count, key }) => (
+                    <div key={key} className="flex items-center gap-1">
+                      <span>{emoji}</span>
+                      <span>{count}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="flex items-center gap-1 mt-1">
+                <span className="text-zinc-700 text-sm">=</span>
+                <span className={`text-lg font-medium ${pr.totalScore >= 0 ? "text-green-600" : "text-red-600"}`}>
+                  {pr.totalScore > 0 ? "+" : ""}
+                  {Math.round(pr.totalScore)}
+                </span>
+              </div>
+            </>
+          )}
         </div>
       </div>
       <div className="mt-3 text-sm text-zinc-500 flex items-center gap-1">

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,9 +1,22 @@
+export interface EmojiCounts {
+  "+1": number;
+  "-1": number;
+  laugh: number;
+  hooray: number;
+  confused: number;
+  heart: number;
+  rocket: number;
+  eyes: number;
+}
+
 export interface PullRequest {
   number: number;
   title: string;
   author: string;
   url: string;
-  votes: number;
+  votes: number; // kept for backward compatibility, equals totalScore
+  emojiCounts: EmojiCounts;
+  totalScore: number;
   createdAt: string;
 }
 
@@ -22,6 +35,18 @@ interface GitHubReaction {
 }
 
 const GITHUB_REPO = "skridlevsky/openchaos";
+
+// Mapping of GitHub reaction types to emojis and scores
+const EMOJI_MAP: Record<string, { emoji: string; score: number }> = {
+  "+1": { emoji: "👍", score: 1 },
+  "-1": { emoji: "👎", score: -1 },
+  laugh: { emoji: "😄", score: 1 },
+  hooray: { emoji: "🎉", score: 1 },
+  confused: { emoji: "😕", score: -1 },
+  heart: { emoji: "❤️", score: 1 },
+  rocket: { emoji: "🚀", score: 1 },
+  eyes: { emoji: "👀", score: -1 },
+};
 
 function getHeaders(accept: string): Record<string, string> {
   const headers: Record<string, string> = { Accept: accept };
@@ -54,23 +79,25 @@ export async function getOpenPRs(): Promise<PullRequest[]> {
   // Fetch reactions for each PR
   const prsWithVotes = await Promise.all(
     prs.map(async (pr) => {
-      const votes = await getPRVotes(owner, repo, pr.number);
+      const { emojiCounts, totalScore } = await getPRReactions(owner, repo, pr.number);
       return {
         number: pr.number,
         title: pr.title,
         author: pr.user.login,
         url: pr.html_url,
-        votes,
+        votes: totalScore, // kept for backward compatibility
+        emojiCounts,
+        totalScore,
         createdAt: pr.created_at,
       };
     }),
   );
 
-  // Sort by votes descending
+  // Sort by total score descending
   return prsWithVotes.sort((a, b) => {
-    // 1. Primary Sort: Net Score
-    if (b.votes !== a.votes) {
-      return b.votes - a.votes;
+    // 1. Primary Sort: Total Score
+    if (b.totalScore !== a.totalScore) {
+      return b.totalScore - a.totalScore;
     }
 
     // 2. Secondary Sort: Creation Date (Newest Wins)
@@ -78,7 +105,11 @@ export async function getOpenPRs(): Promise<PullRequest[]> {
   });
 }
 
-async function getPRVotes(owner: string, repo: string, prNumber: number): Promise<number> {
+async function getPRReactions(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<{ emojiCounts: EmojiCounts; totalScore: number }> {
   let allReactions: GitHubReaction[] = [];
   let page = 1;
 
@@ -110,5 +141,36 @@ async function getPRVotes(owner: string, repo: string, prNumber: number): Promis
     page++;
   }
 
-  return allReactions.filter((r) => r.content === "+1").length - allReactions.filter((r) => r.content === "-1").length;
+  // Initialize emoji counts
+  const emojiCounts: EmojiCounts = {
+    "+1": 0,
+    "-1": 0,
+    laugh: 0,
+    hooray: 0,
+    confused: 0,
+    heart: 0,
+    rocket: 0,
+    eyes: 0,
+  };
+
+  // Count each reaction type
+  for (const reaction of allReactions) {
+    if (reaction.content in emojiCounts) {
+      emojiCounts[reaction.content as keyof EmojiCounts]++;
+    }
+  }
+
+  // Calculate total score
+  let totalScore = 0;
+  for (const [key, count] of Object.entries(emojiCounts)) {
+    const mapping = EMOJI_MAP[key];
+    if (mapping) {
+      totalScore += mapping.score * count;
+    }
+  }
+
+  return { emojiCounts, totalScore };
 }
+
+// Export emoji map for use in components
+export const EMOJI_MAP_EXPORTED = EMOJI_MAP;


### PR DESCRIPTION
This PR updates the PR card display to show all emoji reactions with their counts, separated into positive and negative lines, along with a total calculated score.

- Display all emoji reactions (👍, 👎, 😄, 🎉, 😕, ❤️, 🚀, 👀) with counts
- Update scoring: confused (😕) and eyes (👀) emojis count as -1, the rest as +1

<img width="1283" height="1011" alt="browser-screenshot-1bbfd334-5509-4ea1-a26c-59c5d2111572" src="https://github.com/user-attachments/assets/b13f4118-6df5-4136-a988-7d9633d36104" />
