### PR TITLE
Add auto-refresh for PR data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { Countdown } from "@/components/Countdown";
 import { PRList } from "@/components/PRList";
+import { AutoRefreshWrapper } from "@/components/AutoRefreshWrapper";
 
 export default function Home() {
   return (
@@ -17,15 +18,17 @@ export default function Home() {
         <h2 className="text-xl font-medium text-zinc-600 mb-6">
           Open PRs — Vote to merge
         </h2>
-        <Suspense
-          fallback={
-            <div className="w-full max-w-xl text-center py-8">
-              <p className="text-zinc-500">Loading PRs...</p>
-            </div>
-          }
-        >
-          <PRList />
-        </Suspense>
+        <AutoRefreshWrapper>
+          <Suspense
+            fallback={
+              <div className="w-full max-w-xl text-center py-8">
+                <p className="text-zinc-500">Loading PRs...</p>
+              </div>
+            }
+          >
+            <PRList />
+          </Suspense>
+        </AutoRefreshWrapper>
       </section>
 
       <footer className="mt-16 flex flex-col items-center gap-4 text-sm text-zinc-500">

--- a/src/components/AutoRefreshWrapper.tsx
+++ b/src/components/AutoRefreshWrapper.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+interface AutoRefreshWrapperProps {
+  children: React.ReactNode;
+  intervalMs?: number;
+}
+
+export function AutoRefreshWrapper({
+  children,
+  intervalMs = 300000, // Default: 5 minutes (matches server cache)
+}: AutoRefreshWrapperProps) {
+  const router = useRouter();
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    // Function to refresh the data
+    const refresh = () => {
+      router.refresh();
+    };
+
+    // Handle visibility change
+    const handleVisibilityChange = () => {
+      const isVisible = !document.hidden;
+
+      if (isVisible) {
+        // Tab became visible - refresh immediately
+        refresh();
+
+        // Restart polling if it was cleared
+        if (!intervalRef.current) {
+          intervalRef.current = setInterval(refresh, intervalMs);
+        }
+      } else {
+        // Tab became hidden - stop polling to save resources
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+          intervalRef.current = null;
+        }
+      }
+    };
+
+    // Set up visibility change listener
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    // Start polling if tab is visible
+    if (!document.hidden) {
+      intervalRef.current = setInterval(refresh, intervalMs);
+    }
+
+    // Cleanup
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [router, intervalMs]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
Adds automatic refresh for the PR list every 5 minutes. The refresh pauses when the tab is hidden and immediately refreshes when you switch back to the tab.

This matches the server-side cache time (5 minutes) to avoid unnecessary API calls.