### PR TITLE
Fix pagination bug hiding older PRs

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -34,22 +34,41 @@ function getHeaders(accept: string): Record<string, string> {
 export async function getOpenPRs(): Promise<PullRequest[]> {
   const [owner, repo] = GITHUB_REPO.split("/");
 
-  const response = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/pulls?state=open`,
-    {
-      headers: getHeaders("application/vnd.github.v3+json"),
-      next: { revalidate: 300 }, // Cache for 5 minutes
-    }
-  );
+  let allPRs: GitHubPR[] = [];
+  let page = 1;
 
-  if (!response.ok) {
-    if (response.status === 403) {
-      throw new Error("Rate limited by GitHub API");
+  while (true) {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=100&page=${page}`,
+      {
+        headers: getHeaders("application/vnd.github.v3+json"),
+        next: { revalidate: 300 }, // Cache for 5 minutes
+      }
+    );
+
+    if (!response.ok) {
+      if (response.status === 403) {
+        throw new Error("Rate limited by GitHub API");
+      }
+      throw new Error(`GitHub API error: ${response.status}`);
     }
-    throw new Error(`GitHub API error: ${response.status}`);
+
+    const prs: GitHubPR[] = await response.json();
+
+    if (prs.length === 0) {
+      break;
+    }
+
+    allPRs = allPRs.concat(prs);
+
+    if (prs.length < 100) {
+      break;
+    }
+
+    page++;
   }
 
-  const prs: GitHubPR[] = await response.json();
+  const prs = allPRs;
 
   // Fetch reactions for each PR
   const prsWithVotes = await Promise.all(


### PR DESCRIPTION
GitHub API defaults to 30 results per page. With 37+ open PRs, older ones like #13 were being hidden. This implements proper pagination to fetch all PRs.

## Changes
- Modified `getOpenPRs()` in `src/lib/github.ts` to loop through all pages
- Uses `per_page=100` and increments page number until no more results
- Matches the pagination pattern already used in `getPRVotes()`