### PR TITLE
Add action to set repository name to rustychaos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      - run: '(test "${GITHUB_REPOSITORY}" != "skridlevsky/rustychaos") || (gh api -X PATCH "${GITHUB_REPOSITORY}" "rustychaos")'
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
In preparation to open chaos in rust the repository should be renamed to reflect the upcoming change.