### PR TITLE
allow owner's PRs into the Hall of Chaos

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -228,11 +228,11 @@ export async function getMergedPRs(): Promise<MergedPullRequest[]> {
 
   const prs: GitHubMergedPR[] = await response.json();
 
-  // Filter to only merged PRs (not just closed), exclude repo owner's maintenance PRs
+  // Filter to only merged PRs (not just closed), exclude explicitly listed maintenance PRs
   // Sort by merge time (newest first) since sort=updated may not reflect merge order
-  const REPO_OWNER = owner;
+  const MAINT_PRS = [86]
   return prs
-    .filter((pr) => pr.merged_at !== null && pr.user.login !== REPO_OWNER)
+    .filter((pr) => pr.merged_at !== null && !MAINT_PRS.includes(pr.number))
     .sort((a, b) => new Date(b.merged_at!).getTime() - new Date(a.merged_at!).getTime())
     .map((pr) => ({
       number: pr.number,


### PR DESCRIPTION
Fixes #148. The first pass at an implementation uses an explicitly defined list of PRs to be excluded from the Hall, which would need to be updated in the event of any future maintenance. I'm open to other options such as the addition of a `[maint]` tag to the title of any such future PRs, but there is still the problem of #86 to contend with.

As a side effect, this would allow maintenance PRs from anyone who notices a problem and fixes it, and not just @skridlevsky.