### PR TITLE
🤖 Add MCP Server for AI Agent Access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "16.1.1",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6512,10 +6513,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "dev": true,
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "16.1.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getOpenPRsTool,
+  getMergedPRsTool,
+  getPRDetailsTool,
+  getRepoStatsTool,
+  analyzePRCompetitionTool,
+  GetOpenPRsSchema,
+  GetMergedPRsSchema,
+  GetPRDetailsSchema,
+} from '@/lib/mcp';
+
+// MCP protocol handler for OpenChaos
+// Enables AI agents (Claude, ChatGPT, etc.) to access PR data through Model Context Protocol
+export async function POST(request: NextRequest) {
+  let id = null;
+  try {
+    const body = await request.json();
+    const { jsonrpc, id: requestId, method, params } = body;
+    id = requestId;
+
+    // Validate JSON-RPC 2.0
+    if (jsonrpc !== '2.0') {
+      return NextResponse.json({
+        jsonrpc: '2.0',
+        id: id || null,
+        error: {
+          code: -32600,
+          message: 'Invalid Request: jsonrpc must be "2.0"',
+        },
+      });
+    }
+
+    // Handle MCP protocol methods
+    switch (method) {
+      case 'initialize':
+        return NextResponse.json({
+          jsonrpc: '2.0',
+          id,
+          result: {
+            protocolVersion: '2024-11-05',
+            serverInfo: {
+              name: 'openchaos-mcp',
+              version: '1.0.0',
+            },
+            capabilities: {
+              tools: {},
+            },
+          },
+        });
+
+      case 'tools/list':
+        return NextResponse.json({
+          jsonrpc: '2.0',
+          id,
+          result: {
+            tools: [
+            {
+              name: 'get_open_prs',
+              description: 'Get a list of open pull requests sorted by votes. Returns PR details including vote count, merge status, and CI check status.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  limit: {
+                    type: 'number',
+                    description: 'Maximum number of PRs to return (1-100)',
+                    default: 20,
+                  },
+                  minVotes: {
+                    type: 'number',
+                    description: 'Only return PRs with at least this many votes',
+                  },
+                },
+              },
+            },
+            {
+              name: 'get_merged_prs',
+              description: 'Get a list of recently merged pull requests (Hall of Chaos). Shows the most recent PRs that made it into the main branch.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  limit: {
+                    type: 'number',
+                    description: 'Maximum number of PRs to return (1-50)',
+                    default: 10,
+                  },
+                },
+              },
+            },
+            {
+              name: 'get_pr_details',
+              description: 'Get detailed information about a specific pull request including description, files changed, reactions, and CI status.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  prNumber: {
+                    type: 'number',
+                    description: 'The pull request number',
+                  },
+                },
+                required: ['prNumber'],
+              },
+            },
+            {
+              name: 'get_repo_stats',
+              description: 'Get statistics about the OpenChaos repository including stars, forks, watchers, and open issues count.',
+              inputSchema: {
+                type: 'object',
+                properties: {},
+              },
+            },
+            {
+              name: 'analyze_pr_competition',
+              description: 'Analyze the current PR competition landscape. Returns leaderboard, vote margins, trending PRs, and competitive tiers.',
+              inputSchema: {
+                type: 'object',
+                properties: {},
+              },
+            },
+          ],
+          },
+        });
+
+      case 'tools/call':
+        if (!params?.name) {
+          return NextResponse.json({
+            jsonrpc: '2.0',
+            id,
+            error: {
+              code: -32602,
+              message: 'Invalid params: Tool name is required',
+            },
+          });
+        }
+
+        const { name, arguments: args } = params;
+
+        switch (name) {
+          case 'get_open_prs': {
+            const validated = GetOpenPRsSchema.parse(args || {});
+            const result = await getOpenPRsTool(validated);
+            return NextResponse.json({
+              jsonrpc: '2.0',
+              id,
+              result,
+            });
+          }
+
+          case 'get_merged_prs': {
+            const validated = GetMergedPRsSchema.parse(args || {});
+            const result = await getMergedPRsTool(validated);
+            return NextResponse.json({
+              jsonrpc: '2.0',
+              id,
+              result,
+            });
+          }
+
+          case 'get_pr_details': {
+            const validated = GetPRDetailsSchema.parse(args || {});
+            const result = await getPRDetailsTool(validated);
+            return NextResponse.json({
+              jsonrpc: '2.0',
+              id,
+              result,
+            });
+          }
+
+          case 'get_repo_stats': {
+            const result = await getRepoStatsTool();
+            return NextResponse.json({
+              jsonrpc: '2.0',
+              id,
+              result,
+            });
+          }
+
+          case 'analyze_pr_competition': {
+            const result = await analyzePRCompetitionTool();
+            return NextResponse.json({
+              jsonrpc: '2.0',
+              id,
+              result,
+            });
+          }
+
+          default:
+            return NextResponse.json({
+              jsonrpc: '2.0',
+              id,
+              error: {
+                code: -32601,
+                message: `Method not found: ${name}`,
+              },
+            });
+        }
+
+      default:
+        return NextResponse.json({
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: -32601,
+            message: `Method not found: ${method}`,
+          },
+        });
+    }
+  } catch (error) {
+    console.error('MCP handler error:', error);
+
+    // Zod validation errors
+    if (error && typeof error === 'object' && 'issues' in error) {
+      return NextResponse.json({
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32602,
+          message: 'Invalid params',
+          data: error.issues,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: -32603,
+        message: 'Internal error',
+        data: error instanceof Error ? error.message : 'Unknown error',
+      },
+    });
+  }
+}
+
+// OPTIONS for CORS preflight
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -7,6 +7,14 @@ export interface PullRequest {
   createdAt: string;
 }
 
+export interface MergedPullRequest {
+  number: number;
+  title: string;
+  author: string;
+  url: string;
+  mergedAt: string;
+}
+
 interface GitHubPR {
   number: number;
   title: string;
@@ -15,15 +23,18 @@ interface GitHubPR {
     login: string;
   };
   created_at: string;
+  head: {
+    sha: string;
+  };
 }
 
 interface GitHubReaction {
   content: string;
 }
 
-const GITHUB_REPO = "skridlevsky/openchaos";
+export const GITHUB_REPO = "skridlevsky/openchaos";
 
-function getHeaders(accept: string): Record<string, string> {
+export function getHeaders(accept: string): Record<string, string> {
   const headers: Record<string, string> = { Accept: accept };
   if (process.env.GITHUB_TOKEN) {
     headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
@@ -74,6 +85,7 @@ export async function getOpenPRs(): Promise<PullRequest[]> {
   const prsWithVotes = await Promise.all(
     prs.map(async (pr) => {
       const votes = await getPRVotes(owner, repo, pr.number);
+
       return {
         number: pr.number,
         title: pr.title,
@@ -130,4 +142,48 @@ async function getPRVotes(owner: string, repo: string, prNumber: number): Promis
   }
 
   return allReactions.filter((r) => r.content === "+1").length - allReactions.filter((r) => r.content === "-1").length;
+}
+
+interface GitHubMergedPR {
+  number: number;
+  title: string;
+  html_url: string;
+  user: {
+    login: string;
+  };
+  merged_at: string | null;
+}
+
+export async function getMergedPRs(): Promise<MergedPullRequest[]> {
+  const [owner, repo] = GITHUB_REPO.split("/");
+
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=20`,
+    {
+      headers: getHeaders("application/vnd.github.v3+json"),
+      next: { revalidate: 300 },
+    }
+  );
+
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error("Rate limited by GitHub API");
+    }
+    throw new Error(`GitHub API error: ${response.status}`);
+  }
+
+  const prs: GitHubMergedPR[] = await response.json();
+
+  // Filter to only merged PRs (not just closed), exclude repo owner's maintenance PRs
+  const REPO_OWNER = owner;
+  return prs
+    .filter((pr) => pr.merged_at !== null && pr.user.login !== REPO_OWNER)
+    .sort((a, b) => new Date(b.merged_at!).getTime() - new Date(a.merged_at!).getTime())
+    .map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      author: pr.user.login,
+      url: pr.html_url,
+      mergedAt: pr.merged_at!,
+    }));
 }

--- a/src/lib/mcp/cache.ts
+++ b/src/lib/mcp/cache.ts
@@ -1,0 +1,61 @@
+// Simple in-memory cache with TTL
+// Reduces GitHub API rate limit issues by caching responses for 5 minutes
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry<any>>();
+
+const DEFAULT_TTL = 5 * 60 * 1000; // 5 minutes
+
+export function getCached<T>(key: string): T | null {
+  const entry = cache.get(key);
+
+  if (!entry) {
+    return null;
+  }
+
+  const now = Date.now();
+  if (now - entry.timestamp > DEFAULT_TTL) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.data;
+}
+
+export function setCache<T>(key: string, data: T): void {
+  cache.set(key, {
+    data,
+    timestamp: Date.now(),
+  });
+}
+
+export function clearCache(): void {
+  cache.clear();
+}
+
+// Helper for fetch with caching
+export async function cachedFetch<T>(
+  url: string,
+  options?: RequestInit
+): Promise<T> {
+  const cacheKey = `fetch:${url}:${JSON.stringify(options || {})}`;
+
+  const cached = getCached<T>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  setCache(cacheKey, data);
+
+  return data;
+}

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -1,0 +1,7 @@
+export { getOpenPRsTool } from './tools/get-open-prs';
+export { getMergedPRsTool } from './tools/get-merged-prs';
+export { getPRDetailsTool } from './tools/get-pr-details';
+export { getRepoStatsTool } from './tools/get-repo-stats';
+export { analyzePRCompetitionTool } from './tools/analyze-competition';
+
+export * from './types';

--- a/src/lib/mcp/tools/analyze-competition.ts
+++ b/src/lib/mcp/tools/analyze-competition.ts
@@ -1,0 +1,137 @@
+import { getOpenPRs } from '../../github';
+
+export async function analyzePRCompetitionTool() {
+  try {
+    const prs = await getOpenPRs();
+
+    if (prs.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              message: 'No open pull requests found',
+              analysis: null,
+            }, null, 2),
+          },
+        ],
+      };
+    }
+
+    // Get top PRs by votes
+    const topPR = prs[0]; // Already sorted by votes
+    const secondPR = prs[1];
+    const thirdPR = prs[2];
+
+    // Calculate vote distribution
+    const totalVotes = prs.reduce((sum, pr) => sum + pr.votes, 0);
+    const avgVotes = prs.length > 0 ? totalVotes / prs.length : 0;
+
+    // Find PRs with most momentum (recent activity)
+    const recentPRs = prs
+      .map(pr => ({
+        ...pr,
+        ageInHours: (Date.now() - new Date(pr.createdAt).getTime()) / (1000 * 60 * 60),
+      }))
+      .sort((a, b) => {
+        // Score: votes per hour (for PRs less than 48 hours old)
+        const scoreA = a.ageInHours < 48 ? a.votes / Math.max(a.ageInHours, 1) : 0;
+        const scoreB = b.ageInHours < 48 ? b.votes / Math.max(b.ageInHours, 1) : 0;
+        return scoreB - scoreA;
+      });
+
+    // Vote margin analysis
+    const voteMargins = prs.slice(0, 5).map((pr, index) => {
+      const nextPR = prs[index + 1];
+      return {
+        pr: `#${pr.number} (${pr.votes} votes)`,
+        marginToNext: nextPR ? pr.votes - nextPR.votes : null,
+      };
+    });
+
+    // Competitive tiers
+    const leaders = prs.filter(pr => pr.votes >= avgVotes * 1.5);
+    const contenders = prs.filter(pr => pr.votes >= avgVotes && pr.votes < avgVotes * 1.5);
+    const underdogs = prs.filter(pr => pr.votes < avgVotes);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            summary: {
+              totalPRs: prs.length,
+              totalVotes,
+              averageVotes: Math.round(avgVotes * 10) / 10,
+            },
+            leaderboard: {
+              first: topPR ? {
+                number: topPR.number,
+                title: topPR.title,
+                author: topPR.author,
+                votes: topPR.votes,
+              } : null,
+              second: secondPR ? {
+                number: secondPR.number,
+                title: secondPR.title,
+                author: secondPR.author,
+                votes: secondPR.votes,
+              } : null,
+              third: thirdPR ? {
+                number: thirdPR.number,
+                title: thirdPR.title,
+                author: thirdPR.author,
+                votes: thirdPR.votes,
+              } : null,
+            },
+            momentum: {
+              rising: recentPRs.slice(0, 3).map(pr => ({
+                number: pr.number,
+                title: pr.title,
+                votes: pr.votes,
+                ageInHours: Math.round(pr.ageInHours),
+                votesPerHour: Math.round((pr.votes / Math.max(pr.ageInHours, 1)) * 10) / 10,
+              })),
+            },
+            competition: {
+              voteMargins: voteMargins.filter(m => m.marginToNext !== null),
+              tiers: {
+                leaders: leaders.length,
+                contenders: contenders.length,
+                underdogs: underdogs.length,
+              },
+            },
+          }, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    if (errorMessage.includes('Rate limited')) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: 'GitHub API rate limit exceeded. Please try again later or configure a GITHUB_TOKEN.',
+            }, null, 2),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: `Failed to analyze PR competition: ${errorMessage}`,
+          }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/lib/mcp/tools/get-merged-prs.ts
+++ b/src/lib/mcp/tools/get-merged-prs.ts
@@ -1,0 +1,52 @@
+import { getMergedPRs } from '../../github';
+import { GetMergedPRsInput } from '../types';
+
+export async function getMergedPRsTool(args: GetMergedPRsInput) {
+  try {
+    const allMergedPRs = await getMergedPRs();
+
+    // Apply limit
+    const limitedPRs = allMergedPRs.slice(0, args.limit);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            total: allMergedPRs.length,
+            showing: limitedPRs.length,
+            pullRequests: limitedPRs,
+          }, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    if (errorMessage.includes('Rate limited')) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: 'GitHub API rate limit exceeded. Please try again later or configure a GITHUB_TOKEN.',
+            }, null, 2),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: `Failed to fetch merged PRs: ${errorMessage}`,
+          }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/lib/mcp/tools/get-open-prs.ts
+++ b/src/lib/mcp/tools/get-open-prs.ts
@@ -1,0 +1,60 @@
+import { getOpenPRs } from '../../github';
+import { GetOpenPRsInput } from '../types';
+
+export async function getOpenPRsTool(args: GetOpenPRsInput) {
+  try {
+    const allPRs = await getOpenPRs();
+
+    let filteredPRs = allPRs;
+
+    // Apply minVotes filter if provided
+    if (args.minVotes !== undefined) {
+      const minVotes = args.minVotes;
+      filteredPRs = filteredPRs.filter(pr => pr.votes >= minVotes);
+    }
+
+    // Apply limit
+    const limitedPRs = filteredPRs.slice(0, args.limit);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            total: filteredPRs.length,
+            showing: limitedPRs.length,
+            pullRequests: limitedPRs,
+          }, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    if (errorMessage.includes('Rate limited')) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: 'GitHub API rate limit exceeded. Please try again later or configure a GITHUB_TOKEN.',
+            }, null, 2),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: `Failed to fetch open PRs: ${errorMessage}`,
+          }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/lib/mcp/tools/get-pr-details.ts
+++ b/src/lib/mcp/tools/get-pr-details.ts
@@ -1,0 +1,125 @@
+import { GetPRDetailsInput } from '../types';
+import { cachedFetch } from '../cache';
+import { GITHUB_REPO, getHeaders } from '@/lib/github';
+
+export async function getPRDetailsTool(args: GetPRDetailsInput) {
+  try {
+    const [owner, repo] = GITHUB_REPO.split("/");
+    const { prNumber } = args;
+
+    // Fetch PR details (with caching)
+    const pr = await cachedFetch<any>(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
+      {
+        headers: getHeaders("application/vnd.github.v3+json"),
+      }
+    );
+
+    // Fetch reactions (with caching)
+    let reactions = { upvotes: 0, downvotes: 0 };
+    try {
+      const reactionsData = await cachedFetch<any[]>(
+        `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/reactions`,
+        {
+          headers: getHeaders("application/vnd.github.squirrel-girl-preview+json"),
+        }
+      );
+      reactions = {
+        upvotes: reactionsData.filter((r: any) => r.content === "+1").length,
+        downvotes: reactionsData.filter((r: any) => r.content === "-1").length,
+      };
+    } catch {
+      // Keep default values on error
+    }
+
+    // Fetch commit status (with caching)
+    let checkStatus = "unknown";
+    try {
+      const statusData = await cachedFetch<any>(
+        `https://api.github.com/repos/${owner}/${repo}/commits/${pr.head.sha}/status`,
+        {
+          headers: getHeaders("application/vnd.github.v3+json"),
+        }
+      );
+      checkStatus = statusData.state;
+    } catch {
+      // Keep default value on error
+    }
+
+    // Fetch files changed (with caching)
+    let files: any[] = [];
+    try {
+      const filesData = await cachedFetch<any[]>(
+        `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`,
+        {
+          headers: getHeaders("application/vnd.github.v3+json"),
+        }
+      );
+      files = filesData.map((file: any) => ({
+        filename: file.filename,
+        status: file.status,
+        additions: file.additions,
+        deletions: file.deletions,
+        changes: file.changes,
+      }));
+    } catch {
+      // Keep empty array on error
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            number: pr.number,
+            title: pr.title,
+            author: pr.user.login,
+            state: pr.state,
+            url: pr.html_url,
+            body: pr.body,
+            createdAt: pr.created_at,
+            updatedAt: pr.updated_at,
+            mergedAt: pr.merged_at,
+            mergeable: pr.mergeable,
+            votes: reactions.upvotes - reactions.downvotes,
+            reactions,
+            checkStatus,
+            commits: pr.commits,
+            additions: pr.additions,
+            deletions: pr.deletions,
+            changedFiles: pr.changed_files,
+            files,
+          }, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    if (errorMessage.includes('Rate limited')) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: 'GitHub API rate limit exceeded. Please try again later or configure a GITHUB_TOKEN.',
+            }, null, 2),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: `Failed to fetch PR details: ${errorMessage}`,
+          }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/lib/mcp/tools/get-repo-stats.ts
+++ b/src/lib/mcp/tools/get-repo-stats.ts
@@ -1,0 +1,70 @@
+import { cachedFetch } from '../cache';
+import { GITHUB_REPO, getHeaders } from '@/lib/github';
+
+export async function getRepoStatsTool() {
+  try {
+    const [owner, repo] = GITHUB_REPO.split("/");
+
+    // Fetch repository details (with caching)
+    const repoData = await cachedFetch<any>(
+      `https://api.github.com/repos/${owner}/${repo}`,
+      {
+        headers: getHeaders("application/vnd.github.v3+json"),
+      }
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            name: repoData.name,
+            fullName: repoData.full_name,
+            description: repoData.description,
+            url: repoData.html_url,
+            stars: repoData.stargazers_count,
+            watchers: repoData.watchers_count,
+            forks: repoData.forks_count,
+            openIssues: repoData.open_issues_count,
+            language: repoData.language,
+            createdAt: repoData.created_at,
+            updatedAt: repoData.updated_at,
+            pushedAt: repoData.pushed_at,
+            size: repoData.size,
+            defaultBranch: repoData.default_branch,
+            topics: repoData.topics || [],
+            license: repoData.license?.name || null,
+          }, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    if (errorMessage.includes('Rate limited')) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: 'GitHub API rate limit exceeded. Please try again later or configure a GITHUB_TOKEN.',
+            }, null, 2),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: `Failed to fetch repository stats: ${errorMessage}`,
+          }, null, 2),
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/lib/mcp/types.ts
+++ b/src/lib/mcp/types.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+// Input schemas for MCP tools
+export const GetOpenPRsSchema = z.object({
+  limit: z.number().min(1).max(100).optional().default(20),
+  minVotes: z.number().optional(),
+});
+
+export const GetMergedPRsSchema = z.object({
+  limit: z.number().min(1).max(50).optional().default(10),
+});
+
+export const GetPRDetailsSchema = z.object({
+  prNumber: z.number().int().positive(),
+});
+
+// Type exports
+export type GetOpenPRsInput = z.infer<typeof GetOpenPRsSchema>;
+export type GetMergedPRsInput = z.infer<typeof GetMergedPRsSchema>;
+export type GetPRDetailsInput = z.infer<typeof GetPRDetailsSchema>;


### PR DESCRIPTION
# 🤖 IT'S 2026 AND THE ROBOTS WANT IN

Listen, it's 2026. AI is eating the world. Every repo worth its salt has an MCP server now. If you don't have one, you're basically using punch cards and writing COBOL.

OpenChaos can't be left behind in the AI revolution.

So here we are. The machines have arrived. And they want to participate in the chaos.

---

## What Even Is This?

This PR adds a Model Context Protocol (MCP) server to OpenChaos. Think of it as an API, but for AI agents instead of developers.

Now Claude, ChatGPT, and every other AI assistant can:
- Browse open PRs and their vote counts
- Check the Hall of Chaos (recently merged PRs)
- Get detailed PR info (files, reactions, CI status)
- Analyze the competition landscape
- View repository statistics

Why? Because if humans can vote on PRs through GitHub, why shouldn't AI agents have a seat at the chaos table?

---

## The Tools

Five battle-tested MCP tools, all with proper caching to avoid GitHub rate limits:

**1. get_open_prs** - List all open PRs sorted by votes

**2. get_merged_prs** - The Hall of Chaos in all its glory

**3. get_pr_details** - Deep dive into a specific PR

**4. get_repo_stats** - Repository statistics

**5. analyze_pr_competition** - Competition analysis with leaderboards and vote margins

---

## Testing

This has been rigorously tested in the most demanding environments:

- While on a plane with spotty WiFi at 35,000 feet
- In a bathroom stall during a company all-hands
- At 3 AM when I couldn't sleep and had a sudden fear it wasn't working
- On my phone while pretending to look at something important during a boring meeting
- In a coffee shop where the barista kept misspelling my name
- During a Zoom call with my camera off
- In bed, one eye open, the other firmly closed
- While waiting for my code to compile (the other code, not this code)
- In the parking lot before going into the grocery store
- During the extended edition of Lord of the Rings (all three movies)
- At a red light that felt like it lasted 10 minutes
- While my dinner was microwaving
- In the brief moment between hitting snooze and falling back asleep
- At the DMV (had plenty of time)

All 5 tools work flawlessly in every ridiculous scenario listed above.

But honestly, the bathroom test was the real validation. If it works there, it works anywhere.

---

## The Philosophy

OpenChaos is a democracy experiment where the internet decides what gets merged. It started with humans voting on GitHub.

But we're in 2026 now. AI agents are everywhere. They're reading docs, writing code, analyzing repos. They're part of the internet too.

Shouldn't they get a voice in the chaos?

This MCP server is their seat at the table. It's infrastructure for AI participation. It's the next evolution of the experiment.

Plus, imagine the absolute chaos when multiple AI agents start analyzing PRs and forming opinions. The voting dynamics will get interesting.

---

## Implementation Highlights

- Reuses existing code from \`src/lib/github.ts\`
- Stateless serverless design (no database, no Redis)
- JSON-RPC 2.0 over HTTP
- 5-minute in-memory caching for all GitHub API calls
- Zod validation on all inputs
- Proper error handling and rate limit management

---

## What Could Go Wrong?

Honestly? Not much. Worst case:
- AI agents analyze PRs really fast (that's... good?)
- GitHub rate limits us (we have caching for this)
- The singularity begins at OpenChaos (inevitable anyway)

Best case? AI agents start participating in the chaos, bringing their unique perspectives to the voting process. The experiment evolves. Democracy gets weirder. Everyone wins.

---

## In Conclusion

It's 2026. AI is everywhere. OpenChaos needs to keep up with the times.

This PR adds proper MCP support so AI agents can participate in the chaos alongside humans. It's well-tested (see above), properly cached, and ready for production.

The robots are here. They're ready to vote. Let them in.

---

*Built by @Saturate with enthusiasm for both democracy experiments and robot overlords*