### PR TITLE
Award Board: track your reward hoard

### DIFF
--- a/src/app/ascii/layout.tsx
+++ b/src/app/ascii/layout.tsx
@@ -1,6 +1,11 @@
+"use client";
+
 import { Cat } from "@/components/Cat";
 import { Clippy } from "@/components/ascii/Clippy";
 import { MidiPlayer } from "@/components/MidiPlayer";
+import { VoteTracker } from "@/components/VoteTracker";
+import { useAchievements } from "@/hooks/useAchievements";
+import { useEffect } from "react";
 import "./ascii.css";
 import "./gta-radio.css";
 
@@ -9,8 +14,15 @@ export default function AsciiLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const { trackThemeVisit } = useAchievements();
+
+  useEffect(() => {
+    trackThemeVisit("ascii");
+  }, [trackThemeVisit]);
+
   return (
     <div className="container">
+      <VoteTracker />
       {children}
       <Cat />
       <Clippy />

--- a/src/app/ascii/page.tsx
+++ b/src/app/ascii/page.tsx
@@ -6,6 +6,8 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import { HallOfChaos } from "@/components/ascii/HallOfChaos";
 import { AuthButton } from "@/components/AuthButton";
 import { GuyFieri } from "@/components/GuyFieri";
+import { AwardBoard } from "@/components/ascii/AwardBoard";
+import { CollapsibleSection } from "@/components/ascii/CollapsibleSection";
 
 const title = `
   ___                 ___ _
@@ -41,11 +43,7 @@ export default function AsciiHome() {
           </Suspense>
         </div>
 
-        <div>
-          HALL OF CHAOS - PAST WINNERS
-          <br />
-          ----------------------------
-          <br />
+        <CollapsibleSection title="HALL OF CHAOS - PAST WINNERS" defaultExpanded={false}>
           <Suspense
             fallback={
               <div>
@@ -55,7 +53,9 @@ export default function AsciiHome() {
           >
             <HallOfChaos />
           </Suspense>
-        </div>
+        </CollapsibleSection>
+
+        <AwardBoard />
       </div>
     </>
   );

--- a/src/app/museum/page.tsx
+++ b/src/app/museum/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { MuseumTracker } from "@/components/MuseumTracker";
 import "./museum.css";
 
 export const metadata = {
@@ -9,6 +10,7 @@ export const metadata = {
 export default function MuseumPage() {
   return (
     <div className="museum">
+      <MuseumTracker />
       <header className="museum-header">
         <h1 className="museum-title">OpenChaos Museum</h1>
         <p className="museum-subtitle">Permanent Collection</p>

--- a/src/app/newspaper/layout.tsx
+++ b/src/app/newspaper/layout.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import { VoteTracker } from "@/components/VoteTracker";
+import { useAchievements } from "@/hooks/useAchievements";
+import { useEffect } from "react";
 import "./newspaper.css";
 
 export default function NewspaperLayout({
@@ -5,5 +10,16 @@ export default function NewspaperLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  const { trackThemeVisit } = useAchievements();
+
+  useEffect(() => {
+    trackThemeVisit("newspaper");
+  }, [trackThemeVisit]);
+
+  return (
+    <>
+      <VoteTracker />
+      {children}
+    </>
+  );
 }

--- a/src/app/newspaper/page.tsx
+++ b/src/app/newspaper/page.tsx
@@ -5,6 +5,8 @@ import { NewspaperLayout } from "@/components/newspaper/NewspaperLayout";
 import { HallOfChaos } from "@/components/newspaper/HallOfChaos";
 import { AuthButton } from "@/components/AuthButton";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { AwardBoard } from "@/components/newspaper/AwardBoard";
+import { CollapsibleSection } from "@/components/newspaper/CollapsibleSection";
 
 export default function NewspaperHome() {
   return (
@@ -19,15 +21,13 @@ export default function NewspaperHome() {
         <PRList />
       </Suspense>
 
-      <hr className="np-rule-double" />
+      <CollapsibleSection title="THE ARCHIVES" subtitle="Previously Published Editions" defaultExpanded={false}>
+        <Suspense fallback={<div className="np-loading">Searching the morgue files...</div>}>
+          <HallOfChaos />
+        </Suspense>
+      </CollapsibleSection>
 
-      <div className="np-archives-header">THE ARCHIVES</div>
-      <div className="np-archives-subheader">Previously Published Editions</div>
-      <hr className="np-rule-single" />
-
-      <Suspense fallback={<div className="np-loading">Searching the morgue files...</div>}>
-        <HallOfChaos />
-      </Suspense>
+      <AwardBoard />
     </NewspaperLayout>
   );
 }

--- a/src/app/web2/page.tsx
+++ b/src/app/web2/page.tsx
@@ -7,6 +7,7 @@ import { Web2Layout } from "@/components/Web2Layout";
 import { HallOfChaos } from "@/components/HallOfChaos";
 import { Web2LoadingSpinner } from "@/components/Web2LoadingSpinner";
 import { GuyFieri } from "@/components/GuyFieri";
+import { Web2CollapsibleSection } from "@/components/Web2CollapsibleSection";
 
 export default function Web2Home() {
   return (
@@ -20,16 +21,11 @@ export default function Web2Home() {
         </Suspense>
 
         {/* Hall of Chaos Section */}
-        <div className="web2-section">
-          <div className="web2-section-header">
-            <span className="web2-section-title">Hall of Chaos — Past Winners</span>
-          </div>
-          <div className="web2-section-body">
-            <Suspense fallback={<Web2LoadingSpinner text="Loading history..." />}>
-              <HallOfChaos />
-            </Suspense>
-          </div>
-        </div>
+        <Web2CollapsibleSection title="Hall of Chaos — Past Winners" defaultExpanded={false}>
+          <Suspense fallback={<Web2LoadingSpinner text="Loading history..." />}>
+            <HallOfChaos />
+          </Suspense>
+        </Web2CollapsibleSection>
       </div>
     </Web2Layout>
   );

--- a/src/components/AwardBoard.tsx
+++ b/src/components/AwardBoard.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useAchievements } from "@/hooks/useAchievements";
+
+export function AwardBoard() {
+  const { achievements, unlockedCount, totalCount } = useAchievements();
+
+  return (
+    <div className="web2-widget">
+      <div className="web2-widget-header">
+        🏆 Award Board ({unlockedCount}/{totalCount})
+      </div>
+      <div className="web2-widget-body">
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {achievements.map((achievement: any) => (
+            <div
+              key={achievement.id}
+              className={`achievement-badge ${achievement.unlocked ? "unlocked" : "locked"}`}
+              title={achievement.description}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                padding: "6px 8px",
+                background: achievement.unlocked
+                  ? "linear-gradient(180deg, #fff 0%, #e8f4ff 100%)"
+                  : "linear-gradient(180deg, #f5f5f5 0%, #d0d0d0 100%)",
+                border: achievement.unlocked
+                  ? "2px solid #0066cc"
+                  : "2px solid #999",
+                borderRadius: "4px",
+                fontSize: "11px",
+                fontFamily: "Tahoma, Arial, sans-serif",
+                boxShadow: achievement.unlocked
+                  ? "0 2px 4px rgba(0,102,204,0.3), inset 0 1px 0 rgba(255,255,255,0.8)"
+                  : "0 1px 2px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.5)",
+                opacity: achievement.unlocked ? 1 : 0.5,
+                transition: "all 0.2s ease",
+                cursor: "help",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: "18px",
+                  filter: achievement.unlocked ? "none" : "grayscale(100%)",
+                }}
+              >
+                {achievement.icon}
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    fontWeight: achievement.unlocked ? "bold" : "normal",
+                    color: achievement.unlocked ? "#0066cc" : "#666",
+                    fontSize: "11px",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {achievement.title}
+                </div>
+                <div
+                  style={{
+                    color: "#666",
+                    fontSize: "10px",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {achievement.description}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div
+          style={{
+            marginTop: "12px",
+            padding: "8px",
+            background: "linear-gradient(180deg, #fffbcc 0%, #fff4a3 100%)",
+            border: "1px solid #f0c000",
+            borderRadius: "4px",
+            fontSize: "10px",
+            color: "#666",
+            textAlign: "center",
+          }}
+        >
+          💡 <strong>Tip:</strong> Vote on PRs, explore themes, and visit the
+          museum to unlock more achievements!
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MuseumTracker.tsx
+++ b/src/components/MuseumTracker.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAchievements } from "@/hooks/useAchievements";
+
+export function MuseumTracker() {
+  const { trackMuseumVisit } = useAchievements();
+
+  useEffect(() => {
+    trackMuseumVisit();
+  }, [trackMuseumVisit]);
+
+  return null;
+}

--- a/src/components/VoteTracker.tsx
+++ b/src/components/VoteTracker.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAchievements } from "@/hooks/useAchievements";
+
+export function VoteTracker() {
+  const { trackVote } = useAchievements();
+
+  useEffect(() => {
+    // Listen for vote events
+    const handleVoteSuccess = () => {
+      trackVote();
+    };
+
+    window.addEventListener("vote_success", handleVoteSuccess);
+    return () => window.removeEventListener("vote_success", handleVoteSuccess);
+  }, [trackVote]);
+
+  return null;
+}

--- a/src/components/Web2CollapsibleSection.tsx
+++ b/src/components/Web2CollapsibleSection.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, ReactNode } from "react";
+
+interface Web2CollapsibleSectionProps {
+  title: string;
+  children: ReactNode;
+  defaultExpanded?: boolean;
+}
+
+export function Web2CollapsibleSection({ title, children, defaultExpanded = false }: Web2CollapsibleSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <div className="web2-section">
+      <div 
+        className="web2-section-header"
+        onClick={() => setIsExpanded(!isExpanded)}
+        style={{ cursor: "pointer", userSelect: "none" }}
+      >
+        <span className="web2-section-title">
+          {isExpanded ? "▼" : "▶"} {title}
+        </span>
+      </div>
+      {isExpanded && (
+        <div className="web2-section-body">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Web2Layout.tsx
+++ b/src/components/Web2Layout.tsx
@@ -12,14 +12,25 @@ import { Web2RssIcon } from "./Web2RssIcon";
 import { Web2TagCloud } from "./Web2TagCloud";
 import { Web2SocialBookmarks } from "./Web2SocialBookmarks";
 import { Web2DiggCounter } from "./Web2DiggCounter";
+import { AwardBoard } from "./AwardBoard";
+import { VoteTracker } from "./VoteTracker";
+import { useAchievements } from "@/hooks/useAchievements";
+import { useEffect } from "react";
 
 interface Web2LayoutProps {
   children: ReactNode;
 }
 
 export function Web2Layout({ children }: Web2LayoutProps) {
+  const { trackThemeVisit } = useAchievements();
+
+  useEffect(() => {
+    trackThemeVisit("web2");
+  }, [trackThemeVisit]);
+
   return (
     <>
+      <VoteTracker />
       <CursorTrail />
       <Web2BrowserChrome>
         {/* Announcement Bar */}
@@ -86,6 +97,9 @@ export function Web2Layout({ children }: Web2LayoutProps) {
 
                 {/* Tag Cloud */}
                 <Web2TagCloud />
+
+                {/* Award Board */}
+                <AwardBoard />
 
                 {/* Digg-style Vote Counter */}
                 <Web2DiggCounter />

--- a/src/components/ascii/AwardBoard.tsx
+++ b/src/components/ascii/AwardBoard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useAchievements } from "@/hooks/useAchievements";
+
+export function AwardBoard() {
+  const { achievements, unlockedCount, totalCount } = useAchievements();
+
+  return (
+    <div>
+      <br />
+      {`╔════════════════════════════════════════════╗`}
+      <br />
+      {`║ 🏆 AWARD BOARD (${unlockedCount}/${totalCount})${" ".repeat(Math.max(0, 24 - unlockedCount.toString().length - totalCount.toString().length))}║`}
+      <br />
+      {`╚════════════════════════════════════════════╝`}
+      <br />
+      <br />
+      {achievements.map((achievement) => {
+        const status = achievement.unlocked ? "[✓]" : "[ ]";
+        const icon = achievement.unlocked ? achievement.icon : "🔒";
+        return (
+          <div key={achievement.id} style={{ opacity: achievement.unlocked ? 1 : 0.5 }}>
+            {`${status} ${icon} ${achievement.title}`}
+            <br />
+            {`    ${achievement.description}`}
+            <br />
+            <br />
+          </div>
+        );
+      })}
+      <div style={{ border: "1px solid #666", padding: "8px", marginTop: "8px" }}>
+        💡 Tip: Vote on PRs, explore themes, and visit the
+        <br />
+        museum to unlock more achievements!
+      </div>
+    </div>
+  );
+}

--- a/src/components/ascii/AwardBoard.tsx
+++ b/src/components/ascii/AwardBoard.tsx
@@ -10,7 +10,7 @@ export function AwardBoard() {
       <br />
       {`╔════════════════════════════════════════════╗`}
       <br />
-      {`║ 🏆 AWARD BOARD (${unlockedCount}/${totalCount})${" ".repeat(Math.max(0, 24 - unlockedCount.toString().length - totalCount.toString().length))}║`}
+      {`║ 🏆 AWARD BOARD (${unlockedCount}/${totalCount})${" ".repeat(Math.max(0, 24 - unlockedCount.toString().length - totalCount.toString().length))}`}
       <br />
       {`╚════════════════════════════════════════════╝`}
       <br />

--- a/src/components/ascii/CollapsibleSection.tsx
+++ b/src/components/ascii/CollapsibleSection.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState, ReactNode } from "react";
+
+interface CollapsibleSectionProps {
+  title: string;
+  children: ReactNode;
+  defaultExpanded?: boolean;
+}
+
+export function CollapsibleSection({ title, children, defaultExpanded = false }: CollapsibleSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <div>
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        style={{
+          background: "none",
+          border: "1px solid #666",
+          color: "inherit",
+          padding: "4px 8px",
+          cursor: "pointer",
+          fontSize: "14px",
+          marginBottom: "8px",
+        }}
+      >
+        {isExpanded ? "[-]" : "[+]"} {title}
+      </button>
+      <br />
+      {isExpanded && children}
+    </div>
+  );
+}

--- a/src/components/newspaper/AwardBoard.tsx
+++ b/src/components/newspaper/AwardBoard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useAchievements } from "@/hooks/useAchievements";
+
+export function AwardBoard() {
+  const { achievements, unlockedCount, totalCount } = useAchievements();
+
+  return (
+    <div className="newspaper-widget" style={{ marginTop: "20px" }}>
+      <div className="newspaper-widget-header">
+        <span style={{ fontSize: "16px", fontWeight: "bold" }}>
+          AWARD BOARD
+        </span>
+      </div>
+      <div className="newspaper-widget-body">
+        <p style={{ fontSize: "12px", marginBottom: "12px", fontStyle: "italic" }}>
+          {unlockedCount} of {totalCount} achievements unlocked
+        </p>
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+          {achievements.map((achievement) => (
+            <div
+              key={achievement.id}
+              style={{
+                padding: "8px",
+                border: achievement.unlocked ? "2px solid #000" : "1px solid #999",
+                backgroundColor: achievement.unlocked ? "#f9f9f9" : "#e5e5e5",
+                opacity: achievement.unlocked ? 1 : 0.6,
+                fontFamily: "Georgia, serif",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <span style={{ fontSize: "24px", filter: achievement.unlocked ? "none" : "grayscale(100%)" }}>
+                  {achievement.icon}
+                </span>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: "bold", fontSize: "13px" }}>
+                    {achievement.title}
+                  </div>
+                  <div style={{ fontSize: "11px", color: "#555" }}>
+                    {achievement.description}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div
+          style={{
+            marginTop: "12px",
+            padding: "8px",
+            border: "1px solid #000",
+            backgroundColor: "#fffbcc",
+            fontSize: "11px",
+            fontStyle: "italic",
+          }}
+        >
+          Tip: Vote on PRs, explore themes, and visit the museum to unlock more achievements!
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/newspaper/CollapsibleSection.tsx
+++ b/src/components/newspaper/CollapsibleSection.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, ReactNode } from "react";
+
+interface CollapsibleSectionProps {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  defaultExpanded?: boolean;
+}
+
+export function CollapsibleSection({ title, subtitle, children, defaultExpanded = false }: CollapsibleSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <div>
+      <hr className="np-rule-double" />
+      <div 
+        onClick={() => setIsExpanded(!isExpanded)}
+        style={{ cursor: "pointer", userSelect: "none" }}
+      >
+        <div className="np-archives-header">
+          {isExpanded ? "▼" : "▶"} {title}
+        </div>
+        {subtitle && <div className="np-archives-subheader">{subtitle}</div>}
+      </div>
+      <hr className="np-rule-single" />
+      {isExpanded && children}
+    </div>
+  );
+}

--- a/src/hooks/useAchievements.ts
+++ b/src/hooks/useAchievements.ts
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export interface Achievement {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  unlocked: boolean;
+  unlockedAt?: string;
+}
+
+const ACHIEVEMENTS: Omit<Achievement, "unlocked" | "unlockedAt">[] = [
+  {
+    id: "first_visit",
+    title: "First Visit",
+    description: "Welcome to OpenChaos!",
+    icon: "🌟",
+  },
+  {
+    id: "first_vote",
+    title: "Democracy Rookie",
+    description: "Cast your first vote",
+    icon: "🗳️",
+  },
+  {
+    id: "vote_streak_5",
+    title: "Active Voter",
+    description: "Cast 5 votes",
+    icon: "🔥",
+  },
+  {
+    id: "vote_streak_10",
+    title: "Vote Champion",
+    description: "Cast 10 votes",
+    icon: "🏆",
+  },
+  {
+    id: "vote_streak_25",
+    title: "Democracy Hero",
+    description: "Cast 25 votes",
+    icon: "⭐",
+  },
+  {
+    id: "chaos_explorer",
+    title: "Chaos Explorer",
+    description: "Visit all 3 themes",
+    icon: "🗺️",
+  },
+  {
+    id: "museum_visitor",
+    title: "Cultured Individual",
+    description: "Visit the Museum",
+    icon: "🎨",
+  },
+  {
+    id: "night_owl",
+    title: "Night Owl",
+    description: "Visit after midnight",
+    icon: "🦉",
+  },
+];
+
+export function useAchievements() {
+  const [achievements, setAchievements] = useState<Achievement[]>([]);
+
+  useEffect(() => {
+    loadAchievements();
+    checkAutoUnlockAchievements();
+  }, []);
+
+  function loadAchievements() {
+    try {
+      const stored = localStorage.getItem("openchaos_achievements");
+      const unlocked = stored ? JSON.parse(stored) : {};
+      
+      const loadedAchievements = ACHIEVEMENTS.map((achievement) => ({
+        ...achievement,
+        unlocked: unlocked[achievement.id]?.unlocked || false,
+        unlockedAt: unlocked[achievement.id]?.unlockedAt,
+      }));
+      
+      setAchievements(loadedAchievements);
+    } catch (e) {
+      console.debug("Failed to load achievements:", e);
+      setAchievements(
+        ACHIEVEMENTS.map((achievement) => ({ ...achievement, unlocked: false }))
+      );
+    }
+  }
+
+  function checkAutoUnlockAchievements() {
+    // First visit
+    unlockAchievement("first_visit");
+
+    // Night owl (after midnight)
+    const hour = new Date().getHours();
+    if (hour >= 0 && hour < 6) {
+      unlockAchievement("night_owl");
+    }
+
+    // Check visited themes
+    checkThemeExplorer();
+  }
+
+  function checkThemeExplorer() {
+    try {
+      const visitedThemes = JSON.parse(
+        localStorage.getItem("visited_themes") || "[]"
+      );
+      if (visitedThemes.length >= 3) {
+        unlockAchievement("chaos_explorer");
+      }
+    } catch (e) {
+      console.debug("Failed to check theme explorer:", e);
+    }
+  }
+
+  function unlockAchievement(achievementId: string) {
+    try {
+      const stored = localStorage.getItem("openchaos_achievements");
+      const unlocked = stored ? JSON.parse(stored) : {};
+
+      if (!unlocked[achievementId]) {
+        unlocked[achievementId] = {
+          unlocked: true,
+          unlockedAt: new Date().toISOString(),
+        };
+        localStorage.setItem("openchaos_achievements", JSON.stringify(unlocked));
+        
+        setAchievements((prev: Achievement[]) =>
+          prev.map((achievement: Achievement) =>
+            achievement.id === achievementId
+              ? { ...achievement, unlocked: true, unlockedAt: unlocked[achievementId].unlockedAt }
+              : achievement
+          )
+        );
+
+        // Show a celebration notification (optional)
+        const achievement = ACHIEVEMENTS.find((a: typeof ACHIEVEMENTS[number]) => a.id === achievementId);
+        if (achievement) {
+          console.log(`🎉 Achievement Unlocked: ${achievement.title}!`);
+        }
+      }
+    } catch (e) {
+      console.debug("Failed to unlock achievement:", e);
+    }
+  }
+
+  function trackVote() {
+    try {
+      const voteCount = parseInt(localStorage.getItem("total_votes") || "0", 10);
+      const newVoteCount = voteCount + 1;
+      localStorage.setItem("total_votes", newVoteCount.toString());
+
+      if (newVoteCount === 1) {
+        unlockAchievement("first_vote");
+      } else if (newVoteCount === 5) {
+        unlockAchievement("vote_streak_5");
+      } else if (newVoteCount === 10) {
+        unlockAchievement("vote_streak_10");
+      } else if (newVoteCount === 25) {
+        unlockAchievement("vote_streak_25");
+      }
+    } catch (e) {
+      console.debug("Failed to track vote:", e);
+    }
+  }
+
+  function trackThemeVisit(theme: string) {
+    try {
+      const visitedThemes = JSON.parse(
+        localStorage.getItem("visited_themes") || "[]"
+      );
+      if (!visitedThemes.includes(theme)) {
+        visitedThemes.push(theme);
+        localStorage.setItem("visited_themes", JSON.stringify(visitedThemes));
+        if (visitedThemes.length >= 3) {
+          unlockAchievement("chaos_explorer");
+        }
+      }
+    } catch (e) {
+      console.debug("Failed to track theme visit:", e);
+    }
+  }
+
+  function trackMuseumVisit() {
+    unlockAchievement("museum_visitor");
+  }
+
+  const unlockedCount = achievements.filter((a) => a.unlocked).length;
+  const totalCount = achievements.length;
+
+  return {
+    achievements,
+    unlockedCount,
+    totalCount,
+    unlockAchievement,
+    trackVote,
+    trackThemeVisit,
+    trackMuseumVisit,
+  };
+}

--- a/src/hooks/useVoting.ts
+++ b/src/hooks/useVoting.ts
@@ -156,6 +156,11 @@ export function useVoting(pr: PullRequest, options: VotingOptions = {}): VotingS
         setVoteStatus("success");
         setFeedbackMessage(reaction === "+1" ? feedbackMessages.upvote : feedbackMessages.downvote);
 
+        // Dispatch vote success event for achievement tracking
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new CustomEvent("vote_success"));
+        }
+
         playSound(() => reaction === "+1" ? soundPlayer.playUpvote() : soundPlayer.playDownvote());
         playSound(() => soundPlayer.playSuccess());
 


### PR DESCRIPTION
- Added Award Board widget to the sidebar in ASCII, Web2, and Newspaper layouts displaying 8 achievements
- Achievements unlock for: 
  - first visit
  - voting milestones (i.e.. 1/5/10/25 votes)
  - exploring all themes
  - visiting museum
  - night owl (after midnight)
- Visual progress tracker shows unlocked count in widget header
- Museum visit tracking integrated into museum page
- Makes history list collapsible 

### Newspaper 

<img width="972" height="848" alt="image" src="https://github.com/user-attachments/assets/64498254-a9f8-42ba-8d03-3b0db93e41d8" />


### Web 2.0

<img width="473" height="668" alt="image" src="https://github.com/user-attachments/assets/4a0bdfd6-9eeb-4ab0-8db1-c2ab0e1907d9" />

(and collapsible): 

<img width="684" height="233" alt="image" src="https://github.com/user-attachments/assets/150731fd-4a9b-4b7c-bae7-ce496d304272" />


### ASCII

<img width="691" height="781" alt="image" src="https://github.com/user-attachments/assets/3f55fbfb-bc8f-4a56-9b5f-82074f1c8f0b" />



