### PR TITLE
User profiles will bring smiles for miles

### DIFF
--- a/src/app/ascii/layout.tsx
+++ b/src/app/ascii/layout.tsx
@@ -1,6 +1,7 @@
 import { Cat } from "@/components/Cat";
 import { Clippy } from "@/components/ascii/Clippy";
 import { MidiPlayer } from "@/components/MidiPlayer";
+import { ThemePathProvider } from "@/context/ThemePathContext";
 import "./ascii.css";
 import "./gta-radio.css";
 
@@ -10,11 +11,13 @@ export default function AsciiLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="container">
-      {children}
-      <Cat />
-      <Clippy />
-      <MidiPlayer />
-    </div>
+    <ThemePathProvider themePath="ascii">
+      <div className="container">
+        {children}
+        <Cat />
+        <Clippy />
+        <MidiPlayer />
+      </div>
+    </ThemePathProvider>
   );
 }

--- a/src/app/ascii/page.tsx
+++ b/src/app/ascii/page.tsx
@@ -53,7 +53,7 @@ export default function AsciiHome() {
               </div>
             }
           >
-            <HallOfChaos />
+            <HallOfChaos themePath="ascii" />
           </Suspense>
         </div>
       </div>

--- a/src/app/ascii/users/[username]/page.tsx
+++ b/src/app/ascii/users/[username]/page.tsx
@@ -1,0 +1,32 @@
+import { fetchPRsByAuthor } from "@/lib/prData";
+import { AsciiUserProfile } from "@/components/profile/AsciiUserProfile";
+
+interface PageProps {
+  params: Promise<{ username: string }>;
+}
+
+export default async function AsciiUserProfilePage({ params }: PageProps) {
+  const { username } = await params;
+  const result = await fetchPRsByAuthor(username);
+
+  if (!result.ok) {
+    return (
+      <div>
+        <p>{result.error}</p>
+        <a href="/ascii">← Back to OpenChaos</a>
+      </div>
+    );
+  }
+
+  const { open, merged } = result.data;
+
+  return (
+    <AsciiUserProfile
+      username={username}
+      openPRs={open}
+      mergedPRs={merged}
+      homeHref="/ascii"
+      homeLabel="← Back to OpenChaos"
+    />
+  );
+}

--- a/src/app/newspaper/layout.tsx
+++ b/src/app/newspaper/layout.tsx
@@ -1,3 +1,4 @@
+import { ThemePathProvider } from "@/context/ThemePathContext";
 import "./newspaper.css";
 
 export default function NewspaperLayout({
@@ -5,5 +6,9 @@ export default function NewspaperLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <ThemePathProvider themePath="newspaper">
+      {children}
+    </ThemePathProvider>
+  );
 }

--- a/src/app/newspaper/newspaper.css
+++ b/src/app/newspaper/newspaper.css
@@ -839,3 +839,12 @@
     gap: 4px;
   }
 }
+.user-profile-title {
+  font-size: 2.5rem;
+  margin-bottom:0.5rem;
+  font-weight: 700;
+  font-family: var(--np-headline-font);
+  color: var(--np-ink);
+  letter-spacing: 0.04em;
+  line-height: 1;
+}

--- a/src/app/newspaper/page.tsx
+++ b/src/app/newspaper/page.tsx
@@ -26,7 +26,7 @@ export default function NewspaperHome() {
       <hr className="np-rule-single" />
 
       <Suspense fallback={<div className="np-loading">Searching the morgue files...</div>}>
-        <HallOfChaos />
+        <HallOfChaos themePath="newspaper" />
       </Suspense>
     </NewspaperLayout>
   );

--- a/src/app/newspaper/users/[username]/page.tsx
+++ b/src/app/newspaper/users/[username]/page.tsx
@@ -1,0 +1,37 @@
+import { fetchPRsByAuthor } from "@/lib/prData";
+import { NewspaperUserProfile } from "@/components/profile/NewspaperUserProfile";
+import { NewspaperLayout } from "@/components/newspaper/NewspaperLayout";
+
+interface PageProps {
+  params: Promise<{ username: string }>;
+}
+
+export default async function NewspaperUserProfilePage({ params }: PageProps) {
+  const { username } = await params;
+  const result = await fetchPRsByAuthor(username);
+
+  if (!result.ok) {
+    return (
+      <NewspaperLayout>
+        <div className="np-archives">
+          <p>{result.error}</p>
+          <a href="/newspaper">← Back to OpenChaos</a>
+        </div>
+      </NewspaperLayout>
+    );
+  }
+
+  const { open, merged } = result.data;
+
+  return (
+    <NewspaperLayout>
+      <NewspaperUserProfile
+        username={username}
+        openPRs={open}
+        mergedPRs={merged}
+        homeHref="/newspaper"
+        homeLabel="← Back to OpenChaos"
+      />
+    </NewspaperLayout>
+  );
+}

--- a/src/app/web2/layout.tsx
+++ b/src/app/web2/layout.tsx
@@ -1,4 +1,5 @@
 import { MidiPlayer } from "@/components/MidiPlayer";
+import { ThemePathProvider } from "@/context/ThemePathContext";
 import "./web2.css";
 import "./gta-radio.css";
 
@@ -8,9 +9,9 @@ export default function Web2Layout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <ThemePathProvider themePath="web2">
       {children}
       <MidiPlayer />
-    </>
+    </ThemePathProvider>
   );
 }

--- a/src/app/web2/page.tsx
+++ b/src/app/web2/page.tsx
@@ -26,7 +26,7 @@ export default function Web2Home() {
           </div>
           <div className="web2-section-body">
             <Suspense fallback={<Web2LoadingSpinner text="Loading history..." />}>
-              <HallOfChaos />
+              <HallOfChaos themePath="web2" />
             </Suspense>
           </div>
         </div>

--- a/src/app/web2/users/[username]/page.tsx
+++ b/src/app/web2/users/[username]/page.tsx
@@ -1,0 +1,37 @@
+import { fetchPRsByAuthor } from "@/lib/prData";
+import { Web2UserProfile } from "@/components/profile/Web2UserProfile";
+import { Web2Layout } from "@/components/Web2Layout";
+
+interface PageProps {
+  params: Promise<{ username: string }>;
+}
+
+export default async function Web2UserProfilePage({ params }: PageProps) {
+  const { username } = await params;
+  const result = await fetchPRsByAuthor(username);
+
+  if (!result.ok) {
+    return (
+      <Web2Layout>
+        <div className="page-container">
+          <p>{result.error}</p>
+          <a href="/web2">← Back to OpenChaos</a>
+        </div>
+      </Web2Layout>
+    );
+  }
+
+  const { open, merged } = result.data;
+
+  return (
+    <Web2Layout>
+      <Web2UserProfile
+        username={username}
+        openPRs={open}
+        mergedPRs={merged}
+        homeHref="/web2"
+        homeLabel="← Back to OpenChaos"
+      />
+    </Web2Layout>
+  );
+}

--- a/src/app/web2/web2.css
+++ b/src/app/web2/web2.css
@@ -878,6 +878,39 @@ center {
   margin-top: 0;
 }
 
+/* User profile (web2) — avatar + large username */
+.user-profile-web2 .user-profile-header {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.user-profile-web2 .user-profile-avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  border: 3px solid #d0d8e8;
+  flex-shrink: 0;
+}
+
+[data-theme="dark"] .user-profile-web2 .user-profile-avatar {
+  border-color: #444;
+}
+
+.user-profile-web2 .user-profile-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+  color: #2a5db0;
+  letter-spacing: -0.02em;
+}
+
+[data-theme="dark"] .user-profile-web2 .user-profile-title {
+  color: #5b9bd5;
+}
+
 .page-content-flex {
   display: flex;
   flex-direction: column;

--- a/src/components/HallOfChaos.tsx
+++ b/src/components/HallOfChaos.tsx
@@ -1,7 +1,12 @@
 import { fetchMergedPRs } from "@/lib/prData";
 import { HallOfChaosCard } from "./HallOfChaosCard";
+import { getAuthorProfileHref } from "@/lib/userProfile";
 
-export async function HallOfChaos() {
+interface HallOfChaosProps {
+  themePath?: string;
+}
+
+export async function HallOfChaos({ themePath = "" }: HallOfChaosProps = {}) {
   const result = await fetchMergedPRs();
 
   if (!result.ok) {
@@ -27,7 +32,11 @@ export async function HallOfChaos() {
   return (
     <div className="hall-container">
       {result.data.map((pr) => (
-        <HallOfChaosCard key={pr.number} pr={pr} />
+        <HallOfChaosCard
+          key={pr.number}
+          pr={pr}
+          authorHref={themePath ? getAuthorProfileHref(themePath, pr.author) : undefined}
+        />
       ))}
     </div>
   );

--- a/src/components/HallOfChaosCard.tsx
+++ b/src/components/HallOfChaosCard.tsx
@@ -2,9 +2,11 @@ import type { MergedPullRequest } from "@/lib/github";
 
 interface HallOfChaosCardProps {
   pr: MergedPullRequest;
+  authorHref?: string;
 }
 
-export function HallOfChaosCard({ pr }: HallOfChaosCardProps) {
+export function HallOfChaosCard({ pr, authorHref }: HallOfChaosCardProps) {
+  const link = authorHref ?? `https://github.com/${pr.author}`;
   const mergedDate = new Date(pr.mergedAt).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
@@ -31,9 +33,7 @@ export function HallOfChaosCard({ pr }: HallOfChaosCardProps) {
           <div className="hall-card-meta">
             by{" "}
             <a
-              href={`https://github.com/${pr.author}`}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={link}
               className="hall-card-author-link"
             >
               @{pr.author}

--- a/src/components/PRCard.tsx
+++ b/src/components/PRCard.tsx
@@ -5,6 +5,8 @@ import { hasRhymingWords } from "@/lib/rhymes";
 import { TimeAgo } from "./TimeAgo";
 import { useVoting } from "@/hooks/useVoting";
 import { chooseURL } from "@/lib/utils";
+import { useThemePath } from "@/context/ThemePathContext";
+import { getAuthorProfileHref } from "@/lib/userProfile";
 
 interface PRCardProps {
   pr: PullRequest;
@@ -13,6 +15,8 @@ interface PRCardProps {
 }
 
 export function PRCard({ pr, distinguishLeading = true, scoreLabel = "Net Score" }: PRCardProps) {
+  const themePath = useThemePath();
+  const authorHref = getAuthorProfileHref(themePath, pr.author);
   const {
     cardRef, voteStatus, optimisticVotes, feedbackMessage, showTooltip, showShake,
     showCelebration, errorDetails, canRetry, isAuthenticated, handleVote, retryLastVote, setShowTooltip,
@@ -67,7 +71,7 @@ export function PRCard({ pr, distinguishLeading = true, scoreLabel = "Net Score"
           <div className="pr-card-title">{pr.title}</div>
           <div className="pr-card-meta">
             by{" "}
-            <a href={`https://github.com/${pr.author}`} target="_blank" rel="noopener noreferrer" className="pr-card-author-link">
+            <a href={authorHref} className="pr-card-author-link">
               @{pr.author}
             </a>
             {" · "}

--- a/src/components/ascii/HallOfChaos.tsx
+++ b/src/components/ascii/HallOfChaos.tsx
@@ -1,7 +1,12 @@
 import { fetchMergedPRs } from "@/lib/prData";
 import { HallOfChaosCard } from "./HallOfChaosCard";
+import { getAuthorProfileHref } from "@/lib/userProfile";
 
-export async function HallOfChaos() {
+interface HallOfChaosProps {
+  themePath?: string;
+}
+
+export async function HallOfChaos({ themePath = "" }: HallOfChaosProps = {}) {
   const result = await fetchMergedPRs();
 
   if (!result.ok) {
@@ -28,7 +33,10 @@ export async function HallOfChaos() {
     <div className="mt-4">
       {result.data.map((pr) => (
         <div key={pr.number} style={{ marginBottom: "20px" }}>
-          <HallOfChaosCard pr={pr} />
+          <HallOfChaosCard
+            pr={pr}
+            authorHref={themePath ? getAuthorProfileHref(themePath, pr.author) : undefined}
+          />
         </div>
       ))}
     </div>

--- a/src/components/ascii/HallOfChaosCard.tsx
+++ b/src/components/ascii/HallOfChaosCard.tsx
@@ -3,20 +3,22 @@ import { stripEmojis } from "@/lib/utils";
 
 interface HallOfChaosCardProps {
   pr: MergedPullRequest;
+  authorHref?: string;
 }
 
-export function HallOfChaosCard({ pr }: HallOfChaosCardProps) {
+export function HallOfChaosCard({ pr, authorHref }: HallOfChaosCardProps) {
   const mergedDate = new Date(pr.mergedAt).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
   });
+  const link = authorHref ?? `https://github.com/${pr.author}`;
 
   return (
     <div>
       #{pr.number} [MERGED] {stripEmojis(pr.title)}
       <br />
-      by @{pr.author} · {mergedDate}
+      by <a href={link}>@{pr.author}</a> · {mergedDate}
       <br />
       <a href={pr.url} target="_blank" rel="noopener noreferrer">
         {pr.url}

--- a/src/components/ascii/PRCard.tsx
+++ b/src/components/ascii/PRCard.tsx
@@ -5,6 +5,8 @@ import { hasRhymingWords } from "@/lib/rhymes";
 import { TimeAgo } from "@/components/TimeAgo";
 import { useVoting } from "@/hooks/useVoting";
 import { chooseURL } from "@/lib/utils";
+import { useThemePath } from "@/context/ThemePathContext";
+import { getAuthorProfileHref } from "@/lib/userProfile";
 
 interface PRCardProps {
   pr: PullRequest;
@@ -13,6 +15,8 @@ interface PRCardProps {
 }
 
 export function PRCard({ pr, distinguishLeading = true, scoreLabel = "Net" }: PRCardProps) {
+  const themePath = useThemePath();
+  const authorHref = getAuthorProfileHref(themePath, pr.author);
   const {
     cardRef, voteStatus, optimisticVotes, feedbackMessage, showTooltip, showShake,
     showCelebration, errorDetails, canRetry, isAuthenticated, handleVote, retryLastVote, setShowTooltip,
@@ -100,7 +104,7 @@ export function PRCard({ pr, distinguishLeading = true, scoreLabel = "Net" }: PR
       {/* Line 2: by @author · time */}
       <div>
         &nbsp;&nbsp;&nbsp;&nbsp;by{" "}
-        <a href={`https://github.com/${pr.author}`} target="_blank" rel="noopener noreferrer" className="pr-card-author-link">
+        <a href={authorHref} className="pr-card-author-link">
           @{pr.author}
         </a>{" "}
         · <TimeAgo isoDate={pr.createdAt} />

--- a/src/components/newspaper/HallOfChaos.tsx
+++ b/src/components/newspaper/HallOfChaos.tsx
@@ -1,7 +1,12 @@
 import { fetchMergedPRs } from "@/lib/prData";
 import { HallOfChaosCard } from "./HallOfChaosCard";
+import { getAuthorProfileHref } from "@/lib/userProfile";
 
-export async function HallOfChaos() {
+interface HallOfChaosProps {
+  themePath?: string;
+}
+
+export async function HallOfChaos({ themePath = "" }: HallOfChaosProps = {}) {
   const result = await fetchMergedPRs();
 
   if (!result.ok) {
@@ -24,7 +29,11 @@ export async function HallOfChaos() {
   return (
     <div>
       {result.data.map((pr) => (
-        <HallOfChaosCard key={pr.number} pr={pr} />
+        <HallOfChaosCard
+          key={pr.number}
+          pr={pr}
+          authorHref={themePath ? getAuthorProfileHref(themePath, pr.author) : undefined}
+        />
       ))}
     </div>
   );

--- a/src/components/newspaper/HallOfChaosCard.tsx
+++ b/src/components/newspaper/HallOfChaosCard.tsx
@@ -3,9 +3,10 @@ import { stripEmojis } from "@/lib/utils";
 
 interface HallOfChaosCardProps {
   pr: MergedPullRequest;
+  authorHref?: string;
 }
 
-export function HallOfChaosCard({ pr }: HallOfChaosCardProps) {
+export function HallOfChaosCard({ pr, authorHref }: HallOfChaosCardProps) {
   const parsedDate = new Date(pr.mergedAt);
   const mergedDate = isNaN(parsedDate.getTime())
     ? "Date unknown"
@@ -15,6 +16,7 @@ export function HallOfChaosCard({ pr }: HallOfChaosCardProps) {
         day: "numeric",
         year: "numeric",
       });
+  const link = authorHref ?? `https://github.com/${pr.author}`;
 
   return (
     <div className="np-archive-card">
@@ -29,11 +31,7 @@ export function HallOfChaosCard({ pr }: HallOfChaosCardProps) {
           </div>
           <div className="np-archive-meta">
             by{" "}
-            <a
-              href={`https://github.com/${pr.author}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href={link}>
               @{pr.author}
             </a>
             {" \u00B7 "}

--- a/src/components/newspaper/PRCard.tsx
+++ b/src/components/newspaper/PRCard.tsx
@@ -5,6 +5,8 @@ import { hasRhymingWords } from "@/lib/rhymes";
 import { TimeAgo } from "@/components/TimeAgo";
 import { useVoting } from "@/hooks/useVoting";
 import { chooseURL } from "@/lib/utils";
+import { useThemePath } from "@/context/ThemePathContext";
+import { getAuthorProfileHref } from "@/lib/userProfile";
 
 const NEWSPAPER_VOTING_OPTIONS = {
   confettiColors: ["#8b0000", "#8b7355", "#1a1a1a", "#c4a55a", "#4a0000", "#d4c5a9"],
@@ -29,6 +31,8 @@ interface PRCardProps {
 }
 
 export function PRCard({ pr, isBanner = false, distinguishLeading = true, scoreLabel = "Net Score" }: PRCardProps) {
+  const themePath = useThemePath();
+  const authorHref = getAuthorProfileHref(themePath, pr.author);
   const {
     cardRef, voteStatus, optimisticVotes, feedbackMessage, showTooltip, showShake,
     showCelebration, errorDetails, canRetry, isAuthenticated, handleVote, retryLastVote, setShowTooltip,
@@ -88,7 +92,7 @@ export function PRCard({ pr, isBanner = false, distinguishLeading = true, scoreL
         <div className="np-banner-headline">{pr.title}</div>
         <div className="np-banner-byline">
           by{" "}
-          <a href={`https://github.com/${pr.author}`} target="_blank" rel="noopener noreferrer" style={{ color: "inherit" }}>@{pr.author}</a>
+          <a href={authorHref} style={{ color: "inherit" }}>@{pr.author}</a>
           {" \u00B7 "}<TimeAgo isoDate={pr.createdAt} />{" \u00B7 "}<span className="np-article-number">#{pr.number}</span>
         </div>
         <div className="np-banner-votes">{ballotBox}</div>
@@ -119,7 +123,7 @@ export function PRCard({ pr, isBanner = false, distinguishLeading = true, scoreL
           </div>
           <div className="np-article-byline">
             by{" "}
-            <a href={`https://github.com/${pr.author}`} target="_blank" rel="noopener noreferrer">@{pr.author}</a>
+            <a href={authorHref}>@{pr.author}</a>
             {" \u00B7 "}<TimeAgo isoDate={pr.createdAt} />{" \u00B7 "}<span className="np-article-number">#{pr.number}</span>
           </div>
           <a href={linkHref} target="_blank" rel="noopener noreferrer" className="np-article-link" suppressHydrationWarning>Read Full Story &rarr;</a>

--- a/src/components/profile/AsciiUserProfile.tsx
+++ b/src/components/profile/AsciiUserProfile.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { PullRequest, MergedPullRequest } from "@/lib/github";
+import { ExpandablePRSection } from "@/components/shared/ExpandablePRSection";
+import { PRCard } from "@/components/ascii/PRCard";
+import { HallOfChaosCard } from "@/components/ascii/HallOfChaosCard";
+
+interface AsciiUserProfileProps {
+  username: string;
+  openPRs: PullRequest[];
+  mergedPRs: MergedPullRequest[];
+  homeHref: string;
+  homeLabel: string;
+}
+
+function getBio(username: string, openCount: number, mergedCount: number): string {
+  const openText = openCount === 1 ? "1 open PR" : `${openCount} open PRs`;
+  const mergedText =
+    mergedCount === 1 ? "1 previously merged PR" : `${mergedCount} previously merged PRs`;
+  return `@${username} has ${openText} and ${mergedText}.`;
+}
+
+export function AsciiUserProfile({
+  username,
+  openPRs,
+  mergedPRs,
+  homeHref,
+  homeLabel,
+}: AsciiUserProfileProps) {
+  const authorProfileHref = `${homeHref}/users/${encodeURIComponent(username)}`;
+  const bio = getBio(username, openPRs.length, mergedPRs.length);
+
+  return (
+    <div className="user-profile user-profile-ascii">
+      <p style={{ marginBottom: "1em" }}>
+        <a href={homeHref}>{homeLabel}</a>
+      </p>
+      <h1 className="user-profile-title">@{username}<br/></h1>
+      <p className="user-profile-bio">{bio} <br/></p>
+      
+
+      <section className="user-profile-section" aria-label="Open pull requests">
+        <h2 className="user-profile-section-title">Open PRs:</h2>
+        <br/>
+        <ExpandablePRSection
+          prs={openPRs}
+          PRCardComponent={PRCard}
+          allowDistinguish={false}
+          scoreLabel="Net Score"
+          emptyMessage={<p>No open PRs.</p>}
+          expandLabel={(count) => `Show all (${count})`}
+          collapseLabel="Show less"
+        />
+      </section>
+
+      <section className="user-profile-section" aria-label="Merged pull requests">
+        <h2 className="user-profile-section-title">Merged PRs:</h2>
+        <br/>
+        {mergedPRs.length === 0 ? (
+          <p>No merged PRs yet.</p>
+        ) : (
+          <div className="hall-container">
+            {mergedPRs.map((pr) => (
+              <HallOfChaosCard key={pr.number} pr={pr} authorHref={authorProfileHref} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/profile/NewspaperUserProfile.tsx
+++ b/src/components/profile/NewspaperUserProfile.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { PullRequest, MergedPullRequest } from "@/lib/github";
+import { ExpandablePRSection } from "@/components/shared/ExpandablePRSection";
+import { PRCard } from "@/components/newspaper/PRCard";
+import { HallOfChaosCard } from "@/components/newspaper/HallOfChaosCard";
+
+interface NewspaperUserProfileProps {
+  username: string;
+  openPRs: PullRequest[];
+  mergedPRs: MergedPullRequest[];
+  homeHref: string;
+  homeLabel: string;
+}
+
+function getBio(username: string, openCount: number, mergedCount: number): string {
+  const openText = openCount === 1 ? "1 open PR" : `${openCount} open PRs`;
+  const mergedText =
+    mergedCount === 1 ? "1 previously merged PR" : `${mergedCount} previously merged PRs`;
+  return `@${username} has ${openText} and ${mergedText}.`;
+}
+
+export function NewspaperUserProfile({
+  username,
+  openPRs,
+  mergedPRs,
+  homeHref,
+  homeLabel,
+}: NewspaperUserProfileProps) {
+  const authorProfileHref = `${homeHref}/users/${encodeURIComponent(username)}`;
+  const bio = getBio(username, openPRs.length, mergedPRs.length);
+
+  return (
+    <div className="user-profile user-profile-newspaper">
+      <p style={{ marginBottom: "1em" }}>
+        <a href={homeHref}>{homeLabel}</a>
+      </p>
+      <h1 className="user-profile-title">Articles by @{username}</h1>
+      <p className="user-profile-bio">{bio}</p>
+
+      <section className="user-profile-section" aria-label="Open pull requests">
+        <h2 className="user-profile-section-title">Open PRs</h2>
+        <ExpandablePRSection
+          prs={openPRs}
+          PRCardComponent={PRCard}
+          allowDistinguish={false}
+          scoreLabel="Net Score"
+          emptyMessage={<p>No open PRs.</p>}
+          expandLabel={(count) => `Show all (${count})`}
+          collapseLabel="Show less"
+        />
+      </section>
+
+      <section className="user-profile-section" aria-label="Merged pull requests">
+        <h2 className="user-profile-section-title">Merged — Hall of Chaos</h2>
+        {mergedPRs.length === 0 ? (
+          <p>No merged PRs yet.</p>
+        ) : (
+          <div className="hall-container">
+            {mergedPRs.map((pr) => (
+              <HallOfChaosCard key={pr.number} pr={pr} authorHref={authorProfileHref} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/profile/Web2UserProfile.tsx
+++ b/src/components/profile/Web2UserProfile.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { PullRequest, MergedPullRequest } from "@/lib/github";
+import { ExpandablePRSection } from "@/components/shared/ExpandablePRSection";
+import { PRCard } from "@/components/PRCard";
+import { HallOfChaosCard } from "@/components/HallOfChaosCard";
+
+interface Web2UserProfileProps {
+  username: string;
+  openPRs: PullRequest[];
+  mergedPRs: MergedPullRequest[];
+  homeHref: string;
+  homeLabel: string;
+}
+
+function getBio(username: string, openCount: number, mergedCount: number): string {
+  const openText = openCount === 1 ? "1 open PR" : `${openCount} open PRs`;
+  const mergedText =
+    mergedCount === 1 ? "1 previously merged PR" : `${mergedCount} previously merged PRs`;
+  return `@${username} has ${openText} and ${mergedText}.`;
+}
+
+export function Web2UserProfile({
+  username,
+  openPRs,
+  mergedPRs,
+  homeHref,
+  homeLabel,
+}: Web2UserProfileProps) {
+  const authorProfileHref = `${homeHref}/users/${encodeURIComponent(username)}`;
+  const avatarUrl = `https://github.com/${encodeURIComponent(username)}.png?size=96`;
+  const bio = getBio(username, openPRs.length, mergedPRs.length);
+
+  return (
+    <div className="user-profile user-profile-web2 page-container">
+      <p style={{ marginBottom: "1em" }}>
+        <a href={homeHref}>{homeLabel}</a>
+      </p>
+      <div className="user-profile-header">
+        <img
+          src={avatarUrl}
+          alt=""
+          className="user-profile-avatar"
+          width={96}
+          height={96}
+        />
+        <h1 className="user-profile-title">@{username}</h1>
+      </div>
+      <p className="user-profile-bio">{bio}</p>
+
+      <section className="user-profile-section" aria-label="Open pull requests">
+        <h2 className="user-profile-section-title">Open PRs</h2>
+        <ExpandablePRSection
+          prs={openPRs}
+          PRCardComponent={PRCard}
+          allowDistinguish={false}
+          scoreLabel="Net Score"
+          emptyMessage={<p>No open PRs.</p>}
+          expandLabel={(count) => `Show all (${count})`}
+          collapseLabel="Show less"
+        />
+      </section>
+
+      <section className="user-profile-section" aria-label="Merged pull requests">
+        <h2 className="user-profile-section-title">Merged — Hall of Chaos</h2>
+        {mergedPRs.length === 0 ? (
+          <p>No merged PRs yet.</p>
+        ) : (
+          <div className="hall-container">
+            {mergedPRs.map((pr) => (
+              <HallOfChaosCard key={pr.number} pr={pr} authorHref={authorProfileHref} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/context/ThemePathContext.tsx
+++ b/src/context/ThemePathContext.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+export type ThemePath = "ascii" | "web2" | "newspaper" | "";
+
+const ThemePathContext = createContext<ThemePath>("");
+
+export function ThemePathProvider({
+  themePath,
+  children,
+}: {
+  themePath: ThemePath;
+  children: ReactNode;
+}) {
+  return (
+    <ThemePathContext.Provider value={themePath}>
+      {children}
+    </ThemePathContext.Provider>
+  );
+}
+
+export function useThemePath(): ThemePath {
+  return useContext(ThemePathContext);
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -333,7 +333,7 @@ async function getPRDetail(
   repo: string,
   prNumber: number
 ): Promise<PRDetailResult> {
-  const response = await fetch(
+    const response = await fetch(
     `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
     {
       headers: getHeaders("application/vnd.github.v3+json"),
@@ -459,4 +459,18 @@ export async function getMergedPRs(): Promise<MergedPullRequest[]> {
       url: pr.html_url,
       mergedAt: pr.merged_at!,
     }));
+}
+
+export interface PRsByAuthor {
+  open: PullRequest[];
+  merged: MergedPullRequest[];
+}
+
+/** Get open and merged PRs for a single author (GitHub login). Comparison is case-insensitive. */
+export async function getPRsByAuthor(username: string): Promise<PRsByAuthor> {
+  const lower = username.toLowerCase();
+  const [organized, merged] = await Promise.all([getOrganizedPRs(), getMergedPRs()]);
+  const open = organized.topByVotes.filter((pr) => pr.author.toLowerCase() === lower);
+  const mergedByAuthor = merged.filter((pr) => pr.author.toLowerCase() === lower);
+  return { open, merged: mergedByAuthor };
 }

--- a/src/lib/prData.ts
+++ b/src/lib/prData.ts
@@ -1,7 +1,7 @@
-import { getOrganizedPRs, getMergedPRs } from "@/lib/github";
-import type { OrganizedPRs, MergedPullRequest } from "@/lib/github";
+import { getOrganizedPRs, getMergedPRs, getPRsByAuthor } from "@/lib/github";
+import type { OrganizedPRs, MergedPullRequest, PRsByAuthor } from "@/lib/github";
 
-export type { OrganizedPRs, MergedPullRequest };
+export type { OrganizedPRs, MergedPullRequest, PRsByAuthor };
 
 export async function fetchOrganizedPRs(): Promise<
   { ok: true; data: OrganizedPRs } | { ok: false; error: string }
@@ -24,5 +24,17 @@ export async function fetchMergedPRs(): Promise<
   } catch (e) {
     console.error("Failed to fetch merged PRs:", e);
     return { ok: false, error: e instanceof Error ? e.message : "Failed to fetch merged PRs" };
+  }
+}
+
+export async function fetchPRsByAuthor(username: string): Promise<
+  { ok: true; data: PRsByAuthor } | { ok: false; error: string }
+> {
+  try {
+    const data = await getPRsByAuthor(username);
+    return { ok: true, data };
+  } catch (e) {
+    console.error("Failed to fetch PRs by author:", e);
+    return { ok: false, error: e instanceof Error ? e.message : "Failed to fetch PRs" };
   }
 }

--- a/src/lib/userProfile.ts
+++ b/src/lib/userProfile.ts
@@ -1,0 +1,8 @@
+/**
+ * Build the in-app user profile URL for a theme.
+ * Use this so author links go to /THEME/users/USERNAME instead of github.com/USERNAME.
+ */
+export function getAuthorProfileHref(themePath: string, username: string): string {
+  const base = themePath ? `/${themePath}` : "";
+  return `${base}/users/${encodeURIComponent(username)}`;
+}


### PR DESCRIPTION
Instead of linking to Github, clicking on a username now goes to a dedicated profile page which shows how many PRs the specific user has open and merged.

<img width="535" height="495" alt="Screenshot 2026-03-02 at 10 19 27" src="https://github.com/user-attachments/assets/a40bfb80-8ab6-4912-9f9d-fe9e8ec43bdb" />

<img width="633" height="621" alt="Screenshot 2026-03-02 at 10 19 04" src="https://github.com/user-attachments/assets/b886b67b-bcac-4867-bea4-2431663b0055" />

<img width="953" height="610" alt="Screenshot 2026-03-02 at 10 18 46" src="https://github.com/user-attachments/assets/16217795-af27-4749-83ad-60c8f14cdf61" />
