### PR TITLE
Sequential ranks fill in the blanks

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -262,6 +262,10 @@ export async function getOrganizedPRs(): Promise<OrganizedPRs> {
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
 
+  topByVotes.forEach((pr, index) => {
+    pr.rank = index + 1;
+  });
+
   // Rising: sorted by hot score, conflicts at bottom
   const rising = [...prsWithTrending]
     .sort((a, b) => {


### PR DESCRIPTION
## Summary

- PR ranks in the Top Votes tab now display as sequential 1, 2, 3 instead of showing gaps from global positioning across all PRs

## Screenshots

<img width="642" height="632" alt="Screenshot 2026-03-02 at 8 21 55 PM" src="https://github.com/user-attachments/assets/b1799c75-3c0e-4f41-bcb4-5b668f037593" />
<img width="654" height="578" alt="Screenshot 2026-03-02 at 8 22 22 PM" src="https://github.com/user-attachments/assets/a18fca06-6f16-4a44-b582-12b4c9ac7eab" />
<img width="935" height="600" alt="Screenshot 2026-03-02 at 8 22 40 PM" src="https://github.com/user-attachments/assets/9b6ab176-c291-45b1-8eae-0547d58bb508" />

<!-- chaos-pitch: Vote #1 so the ranks can finally count 1, 2, 3 without skipping -->