### PR TITLE
A welcome popup springs up to say hey, so new visitors don't wander away

### DIFF
--- a/src/app/ascii/layout.tsx
+++ b/src/app/ascii/layout.tsx
@@ -2,6 +2,7 @@ import { Cat } from "@/components/Cat";
 import { Clippy } from "@/components/ascii/Clippy";
 import { MidiPlayer } from "@/components/MidiPlayer";
 import { ThemePathProvider } from "@/context/ThemePathContext";
+import { WelcomePopup } from "@/components/WelcomePopup";
 import "./ascii.css";
 import "./gta-radio.css";
 
@@ -17,6 +18,7 @@ export default function AsciiLayout({
         <Cat />
         <Clippy />
         <MidiPlayer />
+        <WelcomePopup variant="ascii" />
       </div>
     </ThemePathProvider>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import "./globals.css";
+import { WelcomePopup } from "@/components/WelcomePopup";
 
 const chaoticEmojis = [
   "🎯", "🎲", "⚡", "🔥", "💥", "🎪", "🎭", "🎨", "🚀", "⭐", "💫", "🌪️",
@@ -32,6 +33,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         {children}
+        <WelcomePopup />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 import "./globals.css";
-import { WelcomePopup } from "@/components/WelcomePopup";
+
 
 const chaoticEmojis = [
   "🎯", "🎲", "⚡", "🔥", "💥", "🎪", "🎭", "🎨", "🚀", "⭐", "💫", "🌪️",
@@ -33,7 +33,6 @@ export default function RootLayout({
     <html lang="en">
       <body>
         {children}
-        <WelcomePopup />
       </body>
     </html>
   );

--- a/src/app/newspaper/layout.tsx
+++ b/src/app/newspaper/layout.tsx
@@ -1,4 +1,5 @@
 import { ThemePathProvider } from "@/context/ThemePathContext";
+import { WelcomePopup } from "@/components/WelcomePopup";
 import "./newspaper.css";
 
 export default function NewspaperLayout({
@@ -9,6 +10,7 @@ export default function NewspaperLayout({
   return (
     <ThemePathProvider themePath="newspaper">
       {children}
+      <WelcomePopup variant="newspaper" />
     </ThemePathProvider>
   );
 }

--- a/src/app/web2/layout.tsx
+++ b/src/app/web2/layout.tsx
@@ -1,5 +1,6 @@
 import { MidiPlayer } from "@/components/MidiPlayer";
 import { ThemePathProvider } from "@/context/ThemePathContext";
+import { WelcomePopup } from "@/components/WelcomePopup";
 import "./web2.css";
 import "./gta-radio.css";
 
@@ -12,6 +13,7 @@ export default function Web2Layout({
     <ThemePathProvider themePath="web2">
       {children}
       <MidiPlayer />
+      <WelcomePopup variant="web2" />
     </ThemePathProvider>
   );
 }

--- a/src/components/WelcomePopup.tsx
+++ b/src/components/WelcomePopup.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const STORAGE_KEY = "openchaos_welcome_seen";
+
+export function WelcomePopup() {
+  const [isMounted, setIsMounted] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    setIsMounted(true);
+    try {
+      if (localStorage.getItem(STORAGE_KEY)) return;
+    } catch {
+      return;
+    }
+
+    previousFocusRef.current = document.activeElement;
+    const timer = setTimeout(() => {
+      setIsOpen(true);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen && buttonRef.current) {
+      buttonRef.current.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") dismiss();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  });
+
+  function dismiss() {
+    setIsClosing(true);
+    try {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {}
+    setTimeout(() => {
+      setIsOpen(false);
+      setIsClosing(false);
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus();
+      }
+    }, 200);
+  }
+
+  if (!isMounted || !isOpen) return null;
+
+  return (
+    <>
+      <style>{`
+        @keyframes welcomeFadeIn {
+          from { opacity: 0; transform: scale(0.95); }
+          to { opacity: 1; transform: scale(1); }
+        }
+        @keyframes welcomeFadeOut {
+          from { opacity: 1; transform: scale(1); }
+          to { opacity: 0; transform: scale(0.95); }
+        }
+        @keyframes backdropFadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes backdropFadeOut {
+          from { opacity: 1; }
+          to { opacity: 0; }
+        }
+      `}</style>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Welcome to OpenChaos"
+        onClick={dismiss}
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 10000,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "rgba(0, 0, 0, 0.6)",
+          animation: `${isClosing ? "backdropFadeOut" : "backdropFadeIn"} 200ms ease`,
+        }}
+      >
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: "relative",
+            background: "#fff",
+            color: "#1a1a1a",
+            borderRadius: "12px",
+            padding: "32px",
+            maxWidth: "420px",
+            width: "90vw",
+            boxShadow: "0 20px 60px rgba(0, 0, 0, 0.3)",
+            fontFamily: "system-ui, -apple-system, sans-serif",
+            animation: `${isClosing ? "welcomeFadeOut" : "welcomeFadeIn"} 200ms ease`,
+          }}
+        >
+          <button
+            onClick={dismiss}
+            aria-label="Close"
+            style={{
+              position: "absolute",
+              top: "12px",
+              right: "12px",
+              background: "none",
+              border: "none",
+              fontSize: "20px",
+              cursor: "pointer",
+              color: "#999",
+              lineHeight: 1,
+              padding: "4px",
+            }}
+          >
+            ✕
+          </button>
+
+          <h2 style={{ margin: "0 0 16px", fontSize: "22px", fontWeight: 700 }}>
+            What is OpenChaos?
+          </h2>
+
+          <p style={{ margin: "0 0 12px", fontSize: "15px", lineHeight: 1.6, color: "#444" }}>
+            A self-evolving website where the community submits PRs, votes with
+            GitHub reactions, and the winner merges daily at 19:00 UTC.
+          </p>
+
+          <p style={{ margin: "0 0 24px", fontSize: "15px", lineHeight: 1.6, color: "#444" }}>
+            PR titles must rhyme to be eligible.
+          </p>
+
+          <button
+            ref={buttonRef}
+            onClick={dismiss}
+            style={{
+              display: "block",
+              width: "100%",
+              padding: "10px 0",
+              fontSize: "15px",
+              fontWeight: 600,
+              color: "#fff",
+              background: "#111",
+              border: "none",
+              borderRadius: "8px",
+              cursor: "pointer",
+            }}
+          >
+            Got it
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/WelcomePopup.tsx
+++ b/src/components/WelcomePopup.tsx
@@ -4,7 +4,303 @@ import { useEffect, useRef, useState } from "react";
 
 const STORAGE_KEY = "openchaos_welcome_seen";
 
-export function WelcomePopup() {
+type Variant = "ascii" | "web2" | "newspaper";
+
+interface VariantConfig {
+  backdrop: string;
+  cardStyle: React.CSSProperties;
+  closeStyle: React.CSSProperties;
+  heading: React.ReactNode;
+  body: React.ReactNode;
+  buttonStyle: React.CSSProperties;
+  buttonLabel: string;
+  /** Extra chrome rendered before the card body (e.g. title bar) */
+  chrome?: React.ReactNode;
+}
+
+function getConfig(variant: Variant, dismiss: () => void): VariantConfig {
+  switch (variant) {
+    case "ascii":
+      return {
+        backdrop: "rgba(0, 0, 0, 0.85)",
+        cardStyle: {
+          background: "#000",
+          color: "#00ff00",
+          border: "1px solid #00ff00",
+          borderRadius: 0,
+          padding: "32px",
+          maxWidth: "420px",
+          width: "90vw",
+          fontFamily: "monospace",
+          position: "relative",
+        },
+        closeStyle: {
+          position: "absolute",
+          top: "8px",
+          right: "12px",
+          background: "none",
+          border: "none",
+          fontSize: "18px",
+          cursor: "pointer",
+          color: "#00ff00",
+          fontFamily: "monospace",
+          lineHeight: 1,
+          padding: "4px",
+        },
+        heading: (
+          <h2
+            style={{
+              margin: "0 0 16px",
+              fontSize: "18px",
+              fontWeight: 700,
+              fontFamily: "monospace",
+              color: "#00ff00",
+            }}
+          >
+            {">"} WELCOME TO OPENCHAOS.DEV
+          </h2>
+        ),
+        body: (
+          <>
+            <p
+              style={{
+                margin: "0 0 12px",
+                fontSize: "14px",
+                lineHeight: 1.6,
+                color: "#00ff00",
+                fontFamily: "monospace",
+              }}
+            >
+              This site evolves itself. The community submits PRs, votes with
+              GitHub reactions, and the top PR merges daily at 19:00 UTC.
+            </p>
+            <p
+              style={{
+                margin: "0 0 24px",
+                fontSize: "14px",
+                lineHeight: 1.6,
+                color: "#00ff00",
+                fontFamily: "monospace",
+              }}
+            >
+              Warning: PR titles must rhyme to be eligible.
+            </p>
+          </>
+        ),
+        buttonStyle: {
+          display: "block",
+          width: "100%",
+          padding: "10px 0",
+          fontSize: "14px",
+          fontWeight: 600,
+          color: "#00ff00",
+          background: "transparent",
+          border: "1px solid #00ff00",
+          borderRadius: 0,
+          cursor: "pointer",
+          fontFamily: "monospace",
+        },
+        buttonLabel: "[ ENTER ]",
+      };
+
+    case "web2":
+      return {
+        backdrop: "rgba(0, 50, 50, 0.5)",
+        cardStyle: {
+          background: "#f0f0f0",
+          color: "#1a1a1a",
+          border: "2px outset #ddd",
+          borderRadius: 0,
+          padding: 0,
+          maxWidth: "420px",
+          width: "90vw",
+          fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+          position: "relative",
+          overflow: "hidden",
+        },
+        closeStyle: {
+          position: "absolute",
+          top: "4px",
+          right: "8px",
+          background: "none",
+          border: "none",
+          fontSize: "14px",
+          cursor: "pointer",
+          color: "#fff",
+          fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+          fontWeight: 700,
+          lineHeight: 1,
+          padding: "2px 4px",
+          zIndex: 1,
+        },
+        chrome: (
+          <div
+            style={{
+              background: "linear-gradient(180deg, #0058e6 0%, #0040a0 100%)",
+              color: "#fff",
+              padding: "6px 10px",
+              fontSize: "13px",
+              fontWeight: 700,
+              fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+            }}
+          >
+            <span style={{ fontSize: "12px" }}>&#9679;</span> Welcome.exe
+          </div>
+        ),
+        heading: (
+          <h2
+            style={{
+              margin: "0 0 12px",
+              fontSize: "18px",
+              fontWeight: 700,
+              fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+              textAlign: "center",
+            }}
+          >
+            ★ Welcome to OpenChaos! ★
+          </h2>
+        ),
+        body: (
+          <div style={{ padding: "20px 24px 0" }}>
+            <p
+              style={{
+                margin: "0 0 12px",
+                fontSize: "14px",
+                lineHeight: 1.6,
+                color: "#333",
+              }}
+            >
+              This site evolves itself! The community submits PRs, votes with
+              GitHub reactions, and the top PR merges every day at 19:00 UTC.
+            </p>
+            <p
+              style={{
+                margin: "0 0 20px",
+                fontSize: "14px",
+                lineHeight: 1.6,
+                color: "#333",
+              }}
+            >
+              Oh, and PR titles have to rhyme 😎
+            </p>
+          </div>
+        ),
+        buttonStyle: {
+          display: "block",
+          width: "calc(100% - 48px)",
+          margin: "0 24px 20px",
+          padding: "6px 0",
+          fontSize: "13px",
+          fontWeight: 600,
+          color: "#1a1a1a",
+          background: "#dfdfdf",
+          border: "2px outset #ddd",
+          borderRadius: 0,
+          cursor: "pointer",
+          fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+        },
+        buttonLabel: "OK",
+      };
+
+    case "newspaper":
+      return {
+        backdrop: "rgba(0, 0, 0, 0.6)",
+        cardStyle: {
+          background: "#f4ede4",
+          color: "#2a2218",
+          borderRadius: 0,
+          padding: "32px",
+          maxWidth: "420px",
+          width: "90vw",
+          fontFamily: "'Playfair Display', Georgia, 'Times New Roman', serif",
+          position: "relative",
+          borderTop: "4px double #2a2218",
+        },
+        closeStyle: {
+          position: "absolute",
+          top: "12px",
+          right: "12px",
+          background: "none",
+          border: "none",
+          fontSize: "18px",
+          cursor: "pointer",
+          color: "#8a7b6b",
+          fontFamily: "Georgia, 'Times New Roman', serif",
+          lineHeight: 1,
+          padding: "4px",
+        },
+        heading: (
+          <h2
+            style={{
+              margin: "0 0 16px",
+              fontSize: "26px",
+              fontWeight: 700,
+              fontFamily:
+                "'Playfair Display', Georgia, 'Times New Roman', serif",
+              textAlign: "center",
+              letterSpacing: "0.05em",
+              textTransform: "uppercase",
+            }}
+          >
+            Extra! Extra!
+          </h2>
+        ),
+        body: (
+          <>
+            <p
+              style={{
+                margin: "0 0 12px",
+                fontSize: "15px",
+                lineHeight: 1.7,
+                color: "#3d3225",
+                fontFamily: "Georgia, 'Times New Roman', serif",
+              }}
+            >
+              A self-evolving publication where the community submits pull
+              requests, casts votes via GitHub reactions, and the winning edition
+              goes to press daily at 19:00 UTC.
+            </p>
+            <p
+              style={{
+                margin: "0 0 24px",
+                fontSize: "15px",
+                lineHeight: 1.7,
+                color: "#3d3225",
+                fontFamily: "Georgia, 'Times New Roman', serif",
+                fontStyle: "italic",
+              }}
+            >
+              All submissions must bear a rhyming headline.
+            </p>
+          </>
+        ),
+        buttonStyle: {
+          display: "block",
+          width: "100%",
+          padding: "10px 0",
+          fontSize: "15px",
+          fontWeight: 600,
+          color: "#f4ede4",
+          background: "#2a2218",
+          border: "none",
+          borderRadius: 0,
+          cursor: "pointer",
+          fontFamily: "Georgia, 'Times New Roman', serif",
+          letterSpacing: "0.05em",
+        },
+        buttonLabel: "Read On",
+      };
+  }
+}
+
+interface Props {
+  variant?: Variant;
+}
+
+export function WelcomePopup({ variant = "ascii" }: Props) {
   const [isMounted, setIsMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
@@ -57,6 +353,8 @@ export function WelcomePopup() {
 
   if (!isMounted || !isOpen) return null;
 
+  const config = getConfig(variant, dismiss);
+
   return (
     <>
       <style>{`
@@ -89,74 +387,37 @@ export function WelcomePopup() {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "rgba(0, 0, 0, 0.6)",
+          background: config.backdrop,
           animation: `${isClosing ? "backdropFadeOut" : "backdropFadeIn"} 200ms ease`,
         }}
       >
         <div
           onClick={(e) => e.stopPropagation()}
           style={{
-            position: "relative",
-            background: "#fff",
-            color: "#1a1a1a",
-            borderRadius: "12px",
-            padding: "32px",
-            maxWidth: "420px",
-            width: "90vw",
-            boxShadow: "0 20px 60px rgba(0, 0, 0, 0.3)",
-            fontFamily: "system-ui, -apple-system, sans-serif",
+            ...config.cardStyle,
             animation: `${isClosing ? "welcomeFadeOut" : "welcomeFadeIn"} 200ms ease`,
           }}
         >
-          <button
-            onClick={dismiss}
-            aria-label="Close"
-            style={{
-              position: "absolute",
-              top: "12px",
-              right: "12px",
-              background: "none",
-              border: "none",
-              fontSize: "20px",
-              cursor: "pointer",
-              color: "#999",
-              lineHeight: 1,
-              padding: "4px",
-            }}
-          >
+          <button onClick={dismiss} aria-label="Close" style={config.closeStyle}>
             ✕
           </button>
 
-          <h2 style={{ margin: "0 0 16px", fontSize: "22px", fontWeight: 700 }}>
-            What is OpenChaos?
-          </h2>
+          {config.chrome}
 
-          <p style={{ margin: "0 0 12px", fontSize: "15px", lineHeight: 1.6, color: "#444" }}>
-            A self-evolving website where the community submits PRs, votes with
-            GitHub reactions, and the winner merges daily at 19:00 UTC.
-          </p>
+          {variant === "web2" ? (
+            <>
+              <div style={{ padding: "20px 24px 0" }}>{config.heading}</div>
+              {config.body}
+            </>
+          ) : (
+            <>
+              {config.heading}
+              {config.body}
+            </>
+          )}
 
-          <p style={{ margin: "0 0 24px", fontSize: "15px", lineHeight: 1.6, color: "#444" }}>
-            PR titles must rhyme to be eligible.
-          </p>
-
-          <button
-            ref={buttonRef}
-            onClick={dismiss}
-            style={{
-              display: "block",
-              width: "100%",
-              padding: "10px 0",
-              fontSize: "15px",
-              fontWeight: 600,
-              color: "#fff",
-              background: "#111",
-              border: "none",
-              borderRadius: "8px",
-              cursor: "pointer",
-            }}
-          >
-            Got it
+          <button ref={buttonRef} onClick={dismiss} style={config.buttonStyle}>
+            {config.buttonLabel}
           </button>
         </div>
       </div>

--- a/src/themes/features.ts
+++ b/src/themes/features.ts
@@ -14,9 +14,11 @@ export const THEME_FEATURES = {
   midiPlayer:      { description: "Retro MIDI music player", location: "layout" },
   worldChaos:      { description: "Real-time world chaos data display", location: "page" },
   fartscroll:      { description: "Fart sounds on scroll", location: "page" },
+  welcomePopup:    { description: "One-time welcome popup for first-time visitors", location: "root layout" },
 } as const;
 
 // Current feature distribution:
+// root layout:      welcomePopup (all themes)
 // museum page:      fartscroll
 // ascii layout:     clippy(ascii), cat, midiPlayer
 // ascii page:       controlledChaos


### PR DESCRIPTION
Right now if you land on OpenChaos for the first time, there's nothing telling you what it is. You just see a list of PRs and have to figure it out yourself.

This adds a welcome popup that shows once for new visitors, explains the concept, and never appears again (localStorage). Each theme gets its own variant so the popup feels native rather than bolted on.

## Theme variants

Each theme layout passes its own `variant` prop — no runtime theme detection needed:

- **ASCII** — Black background, green monospace text, terminal voice (`> WELCOME TO OPENCHAOS.DEV`), `[ ENTER ]` button
- **Web2** — Window chrome title bar ("Welcome.exe"), 3D outset borders, casual retro voice, `OK` button
- **Newspaper** — Cream paper background, serif fonts, double-rule border, journalistic voice ("EXTRA! EXTRA!"), `Read On` button

## Screenshots

<img width="757" height="538" alt="Screenshot 2026-03-04 at 12 51 50 PM" src="https://github.com/user-attachments/assets/98df1617-2343-4bc4-90f1-9ed138c86b36" />
<img width="950" height="493" alt="Screenshot 2026-03-04 at 12 51 28 PM" src="https://github.com/user-attachments/assets/76a6e067-9889-42a3-9988-2f9166d9d197" />
<img width="972" height="555" alt="Screenshot 2026-03-04 at 12 51 59 PM" src="https://github.com/user-attachments/assets/dbc19a52-eec2-4593-95ff-4536624bc715" />

## Implementation

- `WelcomePopup` accepts an optional `variant` prop (`"ascii" | "web2" | "newspaper"`)
- Moved from root layout into each theme's layout so each theme controls its own variant
- A `getConfig()` function maps each variant to its styles, copy, and button label
- All behavior is unchanged: 500ms delay, localStorage persistence, dismiss via button/X/backdrop/Escape, focus management

## Dismiss methods

Button, X, backdrop click, or Escape key. Shows after a 500ms delay so the page has time to paint first.

<!-- chaos-pitch: First impressions matter — give newcomers a hello instead of a shrug -->