### PR TITLE
Fix the countdown clock to tick toward Saturday's block

### DIFF
--- a/src/components/ascii/Countdown.tsx
+++ b/src/components/ascii/Countdown.tsx
@@ -3,10 +3,10 @@
 import { useCountdown, pad } from "@/hooks/useCountdown";
 
 export function Countdown() {
-  const { hours, minutes, seconds, milliseconds, mounted } = useCountdown(53);
+  const { days, hours, minutes, seconds, milliseconds, mounted } = useCountdown(53);
 
   const display = mounted
-    ? `${pad(hours)} HOURS : ${pad(minutes)} MINS : ${pad(seconds)} SECS : ${pad(milliseconds, 3)} MS`
+    ? `${days} DAYS : ${pad(hours)} HOURS : ${pad(minutes)} MINS : ${pad(seconds)} SECS : ${pad(milliseconds, 3)} MS`
     : "-- DAYS : -- HOURS : -- MINS : -- SECS";
 
   return (

--- a/src/components/newspaper/Countdown.tsx
+++ b/src/components/newspaper/Countdown.tsx
@@ -3,11 +3,11 @@
 import { useCountdown, pad } from "@/hooks/useCountdown";
 
 export function Countdown() {
-  const { hours, minutes, seconds, mounted } = useCountdown();
+  const { days, hours, minutes, seconds, mounted } = useCountdown();
 
   const display = mounted
-    ? `${pad(hours)} HOURS : ${pad(minutes)} MINUTES : ${pad(seconds)} SECONDS`
-    : "-- HOURS : -- MINUTES : -- SECONDS";
+    ? `${days} DAYS : ${pad(hours)} HOURS : ${pad(minutes)} MINUTES : ${pad(seconds)} SECONDS`
+    : "-- DAYS : -- HOURS : -- MINUTES : -- SECONDS";
 
   return (
     <div className="np-countdown-wrap">

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -6,8 +6,12 @@ function getNextMergeTime(): Date {
   const now = new Date();
   const target = new Date(now);
   target.setUTCHours(19, 0, 0, 0);
+  // Merge happens weekly on Saturday (day 6) at 19:00 UTC
+  const day = target.getUTCDay();
+  const daysUntilSaturday = (6 - day + 7) % 7;
+  target.setUTCDate(target.getUTCDate() + daysUntilSaturday);
   if (now.getTime() >= target.getTime()) {
-    target.setUTCDate(target.getUTCDate() + 1);
+    target.setUTCDate(target.getUTCDate() + 7);
   }
   return target;
 }


### PR DESCRIPTION
## Summary
- PR #218 changed the automerge schedule from daily to weekly (Saturdays at 19:00 UTC)
- But it didn't update the countdown timer, which was still counting down to the next daily 19:00 UTC
- This fix updates `useCountdown.ts` to target the next Saturday at 19:00 UTC
- Adds the missing "days" display to the newspaper and ASCII theme countdowns, which previously only showed hours/minutes/seconds