### PR TITLE
Sprinkles arrive so the chaos stays alive

### DIFF
--- a/SPRINKLES.md
+++ b/SPRINKLES.md
@@ -1,0 +1,160 @@
+# Sprinkles
+
+A "sprinkle" is the smallest contribution shape in OpenChaos: one file under
+`src/sprinkles/seeds/`, one entry in the registry, and you're done.
+
+**5 minutes + a rhyme.**
+
+## What can I sprinkle?
+
+Four kinds, each with its own tiny schema. Pick whichever fits your idea.
+
+### `terminal-command`
+
+A hidden command in `ChaosTerminal` (open with `~`).
+
+```ts
+// src/sprinkles/seeds/sneeze.ts
+import type { TerminalCommandSprinkle } from "../types";
+
+export const sneeze: TerminalCommandSprinkle = {
+  id: "sneeze",
+  kind: "terminal-command",
+  author: "your-github-handle",
+  keyword: "achoo",
+  response: [
+    "Gesundheit. The chaos catches a cold.",
+    "Production status: contagious.",
+  ],
+};
+```
+
+`response` can be a string or a string array (one line per element).
+
+### `status-bar-message`
+
+A new scrolling message in the Web2 status bar.
+
+```ts
+// src/sprinkles/seeds/marquee-glee.ts
+import type { StatusBarMessageSprinkle } from "../types";
+
+export const marqueeGlee: StatusBarMessageSprinkle = {
+  id: "marquee-glee",
+  kind: "status-bar-message",
+  author: "your-github-handle",
+  message: "Did you know? PRs that rhyme get to climb.",
+  // weight: 2,  // optional — duplicate in rotation for more airtime
+};
+```
+
+### `cursor-trail`
+
+A glyph set for the cursor trail. The site picks one compatible trail at random per page load.
+
+```ts
+// src/sprinkles/seeds/snow-flow.ts
+import type { CursorTrailSprinkle } from "../types";
+
+export const snowFlow: CursorTrailSprinkle = {
+  id: "snow-flow",
+  kind: "cursor-trail",
+  author: "your-github-handle",
+  glyphs: ["❄", "❅", "❆", "·"],
+  fadeMs: 600,    // optional — how long each glyph stays visible
+  throttleMs: 70, // optional — min ms between emits
+};
+```
+
+### `page-load-cameo`
+
+A brief one-shot visual rendered on page load. Use sparingly — multiple compatible
+cameos render at once.
+
+```tsx
+// src/sprinkles/seeds/hello-cello.tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import type { PageLoadCameoSprinkle } from "../types";
+
+function HelloCello() {
+  const [show, setShow] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => setShow(false), 900);
+    return () => clearTimeout(t);
+  }, []);
+  if (!show) return null;
+  return (
+    <div style={{ position: "fixed", top: 16, left: "50%", pointerEvents: "none" }}>
+      🎻
+    </div>
+  );
+}
+
+export const helloCello: PageLoadCameoSprinkle = {
+  id: "hello-cello",
+  kind: "page-load-cameo",
+  author: "your-github-handle",
+  Component: HelloCello,
+  durationMs: 900,
+};
+```
+
+## Theme compatibility
+
+Sprinkles default to compatible with all four themes (`ascii`, `web2`, `newspaper`,
+`vaporwave`). If your sprinkle clashes with a particular theme — say, an emoji
+trail that breaks the ASCII vibe — declare it:
+
+```ts
+incompatibleThemes: ["ascii"],
+```
+
+You don't have to study every theme before shipping. Be a good citizen, declare
+clashes you spot, and let the community catch the rest.
+
+## How a sprinkle activates
+
+- `terminal-command` — merged into the command table. Hardcoded commands win on a
+  keyword collision.
+- `status-bar-message` — appended to the rotation list. Use `weight` for more airtime.
+- `cursor-trail` — one compatible sprinkle is chosen at random per page load.
+- `page-load-cameo` — every compatible sprinkle renders simultaneously on mount.
+
+## Registering your sprinkle
+
+Add an import + entry to `src/sprinkles/registry.ts`:
+
+```ts
+import { snowFlow } from "./seeds/snow-flow";
+
+export const SPRINKLES: readonly Sprinkle[] = [
+  // ...existing entries
+  snowFlow,
+];
+```
+
+No filesystem auto-discovery. The explicit list keeps review legible.
+
+## Escape hatch
+
+Append `?sprinkles=off` to any URL to disable all sprinkles for that session.
+Useful for screenshots, bug reports, and theme development.
+
+## PR rules — unchanged
+
+Sprinkle PRs follow the same rules as any other:
+
+- Title must contain at least two rhyming words (each > 2 characters).
+- CI build must pass.
+- Net votes ≥ 10 to be merge-eligible.
+- Must be conflict-free.
+
+## Why this exists
+
+The asymmetry between drive-by interest and a full theme build (~220 lines, 6+
+files) was keeping a lot of would-be contributors as lurkers. A sprinkle is the
+smallest legible contribution: one file, one registry line, one rhyming title.
+
+Have at it.

--- a/src/app/ascii/layout.tsx
+++ b/src/app/ascii/layout.tsx
@@ -3,6 +3,7 @@ import { Clippy } from "@/components/ascii/Clippy";
 import { MidiPlayer } from "@/components/MidiPlayer";
 import { ThemePathProvider } from "@/context/ThemePathContext";
 import { WelcomePopup } from "@/components/WelcomePopup";
+import { Sprinkles } from "@/sprinkles/Sprinkles";
 import "./ascii.css";
 import "./gta-radio.css";
 
@@ -19,6 +20,7 @@ export default function AsciiLayout({
         <Clippy />
         <MidiPlayer />
         <WelcomePopup variant="ascii" />
+        <Sprinkles kind="page-load" />
       </div>
     </ThemePathProvider>
   );

--- a/src/app/newspaper/layout.tsx
+++ b/src/app/newspaper/layout.tsx
@@ -1,5 +1,6 @@
 import { ThemePathProvider } from "@/context/ThemePathContext";
 import { WelcomePopup } from "@/components/WelcomePopup";
+import { Sprinkles } from "@/sprinkles/Sprinkles";
 import "./newspaper.css";
 
 export default function NewspaperLayout({
@@ -11,6 +12,7 @@ export default function NewspaperLayout({
     <ThemePathProvider themePath="newspaper">
       {children}
       <WelcomePopup variant="newspaper" />
+      <Sprinkles kind="page-load" />
     </ThemePathProvider>
   );
 }

--- a/src/app/vaporwave/layout.tsx
+++ b/src/app/vaporwave/layout.tsx
@@ -1,4 +1,6 @@
 import { CursorTrail } from "@/components/CursorTrail";
+import { ThemePathProvider } from "@/context/ThemePathContext";
+import { Sprinkles } from "@/sprinkles/Sprinkles";
 import "./vaporwave.css";
 
 export default function VaporwaveLayout({
@@ -7,9 +9,12 @@ export default function VaporwaveLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="vw-container">
-      {children}
-      <CursorTrail />
-    </div>
+    <ThemePathProvider themePath="vaporwave">
+      <div className="vw-container">
+        {children}
+        <CursorTrail />
+        <Sprinkles kind="page-load" />
+      </div>
+    </ThemePathProvider>
   );
 }

--- a/src/app/web2/layout.tsx
+++ b/src/app/web2/layout.tsx
@@ -1,6 +1,7 @@
 import { MidiPlayer } from "@/components/MidiPlayer";
 import { ThemePathProvider } from "@/context/ThemePathContext";
 import { WelcomePopup } from "@/components/WelcomePopup";
+import { Sprinkles } from "@/sprinkles/Sprinkles";
 import "./web2.css";
 import "./gta-radio.css";
 
@@ -14,6 +15,7 @@ export default function Web2Layout({
       {children}
       <MidiPlayer />
       <WelcomePopup variant="web2" />
+      <Sprinkles kind="page-load" />
     </ThemePathProvider>
   );
 }

--- a/src/components/ChaosTerminal.tsx
+++ b/src/components/ChaosTerminal.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { soundPlayer } from "@/utils/sounds";
+import { useThemePath } from "@/context/ThemePathContext";
+import { SPRINKLES } from "@/sprinkles/registry";
+import { sprinklesForTheme } from "@/sprinkles/filter";
+import { useSprinklesEnabled } from "@/sprinkles/useSprinklesEnabled";
 
 const BOOT_LINES = [
   "CHAOS BIOS v6.6.6 - Entropy Unlimited Inc.",
@@ -183,6 +187,13 @@ export function ChaosTerminal() {
   const [isBooting, setIsBooting] = useState(true);
   const [isAnimating, setIsAnimating] = useState(false);
   const [mounted, setMounted] = useState(false);
+
+  const theme = useThemePath();
+  const sprinklesEnabled = useSprinklesEnabled();
+  const sprinkleCommands = useMemo(
+    () => sprinklesForTheme(SPRINKLES, "terminal-command", theme),
+    [theme],
+  );
 
   const inputRef = useRef<HTMLInputElement>(null);
   const outputRef = useRef<HTMLDivElement>(null);
@@ -616,13 +627,22 @@ export function ChaosTerminal() {
           break;
         }
 
-        default:
-          addLines(
-            `chaos: ${trimmed.split(" ")[0]}: command not found. Try 'help'.`
-          );
+        default: {
+          const match = sprinklesEnabled
+            ? sprinkleCommands.find((s) => s.keyword.toLowerCase() === lower)
+            : undefined;
+          if (match) {
+            const responseLines = Array.isArray(match.response) ? match.response : [match.response];
+            addLines(...responseLines);
+          } else {
+            addLines(
+              `chaos: ${trimmed.split(" ")[0]}: command not found. Try 'help'.`
+            );
+          }
+        }
       }
     },
-    [addLines, closeTerminal, runAnimatedSequence]
+    [addLines, closeTerminal, runAnimatedSequence, sprinkleCommands, sprinklesEnabled]
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/CursorTrail.tsx
+++ b/src/components/CursorTrail.tsx
@@ -1,61 +1,89 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useThemePath } from "@/context/ThemePathContext";
+import { SPRINKLES } from "@/sprinkles/registry";
+import { sprinklesForTheme } from "@/sprinkles/filter";
+import { useSprinklesEnabled } from "@/sprinkles/useSprinklesEnabled";
 
 interface CursorPoint {
   id: number;
   x: number;
   y: number;
+  glyph: string;
 }
+
+const DEFAULT_GLYPH = "·";
+const DEFAULT_FADE_MS = 500;
+const DEFAULT_THROTTLE_MS = 80;
 
 export function CursorTrail() {
   const [cursors, setCursors] = useState<CursorPoint[]>([]);
-  const [emoji, setEmoji] = useState("·");
+  const [konamiOverride, setKonamiOverride] = useState<string | null>(null);
+  const glyphIndexRef = useRef(0);
+
+  const theme = useThemePath();
+  const sprinklesEnabled = useSprinklesEnabled();
+
+  const eligible = useMemo(
+    () => sprinklesForTheme(SPRINKLES, "cursor-trail", theme),
+    [theme],
+  );
+
+  // Pick one compatible sprinkle at random per mount (per page load).
+  const active = useMemo(() => {
+    if (!sprinklesEnabled || eligible.length === 0) return null;
+    return eligible[Math.floor(Math.random() * eligible.length)];
+  }, [eligible, sprinklesEnabled]);
+
+  const glyphs = active?.glyphs ?? [DEFAULT_GLYPH];
+  const fadeMs = active?.fadeMs ?? DEFAULT_FADE_MS;
+  const throttleMs = active?.throttleMs ?? DEFAULT_THROTTLE_MS;
 
   useEffect(() => {
     let cursorId = 0;
 
-    const handleMouseMove = (e: MouseEvent) => {
-      const newCursor: CursorPoint = {
+    const emit = (e: MouseEvent) => {
+      const glyph = konamiOverride ?? glyphs[glyphIndexRef.current % glyphs.length];
+      glyphIndexRef.current += 1;
+      const point: CursorPoint = {
         id: cursorId++,
         x: e.clientX,
-        y: e.clientY
+        y: e.clientY,
+        glyph,
       };
-
-      setCursors((prev) => [...prev, newCursor]);
-
+      setCursors((prev) => [...prev, point]);
       setTimeout(() => {
-        setCursors((prev) => prev.filter((c) => c.id !== newCursor.id));
-      }, 500);
+        setCursors((prev) => prev.filter((c) => c.id !== point.id));
+      }, fadeMs);
     };
 
-    let throttleTimer: NodeJS.Timeout | null = null;
-    const throttledMouseMove = (e: MouseEvent) => {
+    let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+    const throttled = (e: MouseEvent) => {
       if (throttleTimer) return;
       throttleTimer = setTimeout(() => {
-        handleMouseMove(e);
+        emit(e);
         throttleTimer = null;
-      }, 80);
+      }, throttleMs);
     };
 
-    window.addEventListener("mousemove", throttledMouseMove);
-
+    window.addEventListener("mousemove", throttled);
     return () => {
-      window.removeEventListener("mousemove", throttledMouseMove);
+      window.removeEventListener("mousemove", throttled);
       if (throttleTimer) clearTimeout(throttleTimer);
     };
-  }, []);
+  }, [glyphs, fadeMs, throttleMs, konamiOverride]);
 
   useEffect(() => {
-    const code = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
+    const code = ["ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown", "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight", "b", "a"];
     let pos = 0;
 
     const handleKey = (e: KeyboardEvent) => {
       const key = e.key.toLowerCase();
-      if (key === code[pos] || e.key === code[pos]) {
+      if (key === code[pos].toLowerCase() || e.key === code[pos]) {
         pos++;
         if (pos === code.length) {
-          setEmoji("🔫");
+          setKonamiOverride("🔫");
           pos = 0;
         }
       } else {
@@ -81,10 +109,10 @@ export function CursorTrail() {
             fontSize: "12px",
             userSelect: "none",
             color: "#2a5db0",
-            opacity: 0.4,
+            opacity: 0.6,
           }}
         >
-          {emoji}
+          {cursor.glyph}
         </div>
       ))}
     </div>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useThemePath } from "@/context/ThemePathContext";
+import { SPRINKLES } from "@/sprinkles/registry";
+import { sprinklesForTheme } from "@/sprinkles/filter";
+import { useSprinklesEnabled } from "@/sprinkles/useSprinklesEnabled";
 
 const STATUS_MESSAGES = [
   "Welcome to OpenChaos.dev — powered by AJAX and community votes",
@@ -18,13 +22,24 @@ const STATUS_MESSAGES = [
 ];
 
 export function StatusBar() {
+  const theme = useThemePath();
+  const sprinklesEnabled = useSprinklesEnabled();
+
+  const messages = useMemo(() => {
+    if (!sprinklesEnabled) return STATUS_MESSAGES;
+    const extras = sprinklesForTheme(SPRINKLES, "status-bar-message", theme).flatMap((s) => {
+      const weight = Math.max(1, Math.floor(s.weight ?? 1));
+      return Array.from({ length: weight }, () => s.message);
+    });
+    return [...STATUS_MESSAGES, ...extras];
+  }, [theme, sprinklesEnabled]);
+
   const [currentMessage, setCurrentMessage] = useState("");
   const [messageIndex, setMessageIndex] = useState(0);
   const [charIndex, setCharIndex] = useState(0);
 
-  // Scroll through messages character by character
   useEffect(() => {
-    const message = STATUS_MESSAGES[messageIndex];
+    const message = messages[messageIndex % messages.length];
 
     if (charIndex < message.length) {
       const timer = setTimeout(() => {
@@ -33,15 +48,14 @@ export function StatusBar() {
       }, 50);
       return () => clearTimeout(timer);
     } else {
-      // Pause at end of message
       const timer = setTimeout(() => {
         setCharIndex(0);
         setCurrentMessage("");
-        setMessageIndex((messageIndex + 1) % STATUS_MESSAGES.length);
+        setMessageIndex((messageIndex + 1) % messages.length);
       }, 1337);
       return () => clearTimeout(timer);
     }
-  }, [charIndex, messageIndex]);
+  }, [charIndex, messageIndex, messages]);
 
   return (
     <div className="status-bar">

--- a/src/context/ThemePathContext.tsx
+++ b/src/context/ThemePathContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, type ReactNode } from "react";
 
-export type ThemePath = "ascii" | "web2" | "newspaper" | "";
+export type ThemePath = "ascii" | "web2" | "newspaper" | "vaporwave" | "";
 
 const ThemePathContext = createContext<ThemePath>("");
 

--- a/src/sprinkles/Sprinkles.tsx
+++ b/src/sprinkles/Sprinkles.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useMemo } from "react";
+import { useThemePath } from "@/context/ThemePathContext";
+import { SPRINKLES } from "./registry";
+import { sprinklesForTheme } from "./filter";
+import { useSprinklesEnabled } from "./useSprinklesEnabled";
+
+interface SprinklesProps {
+  kind: "page-load";
+}
+
+export function Sprinkles({ kind }: SprinklesProps) {
+  const theme = useThemePath();
+  const enabled = useSprinklesEnabled();
+
+  const cameos = useMemo(
+    () => sprinklesForTheme(SPRINKLES, "page-load-cameo", theme),
+    [theme],
+  );
+
+  if (!enabled) return null;
+  if (kind !== "page-load") return null;
+  if (cameos.length === 0) return null;
+
+  return (
+    <>
+      {cameos.map((sprinkle) => {
+        const Cameo = sprinkle.Component;
+        return <Cameo key={sprinkle.id} />;
+      })}
+    </>
+  );
+}

--- a/src/sprinkles/filter.ts
+++ b/src/sprinkles/filter.ts
@@ -1,0 +1,21 @@
+import type { RouteGroup } from "@/lib/chaos-router";
+import { ROUTE_GROUPS } from "@/lib/chaos-router";
+import type { Sprinkle, SprinkleKind, SprinkleOfKind } from "./types";
+
+function isRouteGroup(theme: string): theme is RouteGroup {
+  return (ROUTE_GROUPS as readonly string[]).includes(theme);
+}
+
+export function sprinklesForTheme<K extends SprinkleKind>(
+  sprinkles: readonly Sprinkle[],
+  kind: K,
+  theme: string,
+): SprinkleOfKind<K>[] {
+  const ofKind = sprinkles.filter(
+    (s): s is SprinkleOfKind<K> => s.kind === kind,
+  );
+  if (!isRouteGroup(theme)) {
+    return ofKind;
+  }
+  return ofKind.filter((s) => !s.incompatibleThemes?.includes(theme));
+}

--- a/src/sprinkles/index.ts
+++ b/src/sprinkles/index.ts
@@ -1,0 +1,13 @@
+export type {
+  Sprinkle,
+  SprinkleKind,
+  SprinkleOfKind,
+  TerminalCommandSprinkle,
+  StatusBarMessageSprinkle,
+  CursorTrailSprinkle,
+  PageLoadCameoSprinkle,
+} from "./types";
+export { SPRINKLES } from "./registry";
+export { sprinklesForTheme } from "./filter";
+export { useSprinklesEnabled } from "./useSprinklesEnabled";
+export { Sprinkles } from "./Sprinkles";

--- a/src/sprinkles/registry.ts
+++ b/src/sprinkles/registry.ts
@@ -1,0 +1,17 @@
+import type { Sprinkle } from "./types";
+import { chaosFortune } from "./seeds/chaos-fortune";
+import { rhymeOfTheDay } from "./seeds/rhyme-of-the-day";
+import { sparkleTrail } from "./seeds/sparkle-trail";
+import { entryFirework } from "./seeds/entry-firework";
+
+/**
+ * Every sprinkle in the site is registered here. Adding a sprinkle = adding
+ * one implementation file under seeds/ plus one entry below. Explicit list
+ * keeps narrowing easy and contribution review legible.
+ */
+export const SPRINKLES: readonly Sprinkle[] = [
+  chaosFortune,
+  rhymeOfTheDay,
+  sparkleTrail,
+  entryFirework,
+];

--- a/src/sprinkles/seeds/chaos-fortune.ts
+++ b/src/sprinkles/seeds/chaos-fortune.ts
@@ -1,0 +1,14 @@
+import type { TerminalCommandSprinkle } from "../types";
+
+export const chaosFortune: TerminalCommandSprinkle = {
+  id: "chaos-fortune",
+  kind: "terminal-command",
+  author: "openchaos",
+  keyword: "sprinkle",
+  response: [
+    "A sprinkle drifts in on the wind —",
+    "your PR might just merge in the end.",
+    "",
+    "Type `help` for the full menu of chaos.",
+  ],
+};

--- a/src/sprinkles/seeds/entry-firework.tsx
+++ b/src/sprinkles/seeds/entry-firework.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { PageLoadCameoSprinkle } from "../types";
+
+const GLYPHS = ["✨", "✳", "✴", "✪", "✷"];
+const DURATION_MS = 1100;
+
+function EntryFireworkCameo() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(false), DURATION_MS);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "fixed",
+        inset: 0,
+        pointerEvents: "none",
+        zIndex: 9998,
+        overflow: "hidden",
+      }}
+    >
+      <style>{`
+        @keyframes sprinkle-entry-firework {
+          0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+          25% { opacity: 1; }
+          100% { transform: var(--sprinkle-target, translate(0, -120px)) scale(1); opacity: 0; }
+        }
+      `}</style>
+      {GLYPHS.map((glyph, i) => {
+        const angle = (i / GLYPHS.length) * Math.PI * 2;
+        const distance = 90;
+        const tx = Math.cos(angle) * distance;
+        const ty = Math.sin(angle) * distance;
+        return (
+          <div
+            key={i}
+            style={{
+              position: "absolute",
+              left: "50%",
+              top: "50%",
+              fontSize: "24px",
+              animation: `sprinkle-entry-firework ${DURATION_MS}ms ease-out forwards`,
+              ["--sprinkle-target" as string]: `translate(${tx.toFixed(1)}px, ${ty.toFixed(1)}px)`,
+            }}
+          >
+            {glyph}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export const entryFirework: PageLoadCameoSprinkle = {
+  id: "entry-firework",
+  kind: "page-load-cameo",
+  author: "openchaos",
+  Component: EntryFireworkCameo,
+  durationMs: DURATION_MS,
+};

--- a/src/sprinkles/seeds/rhyme-of-the-day.ts
+++ b/src/sprinkles/seeds/rhyme-of-the-day.ts
@@ -1,0 +1,9 @@
+import type { StatusBarMessageSprinkle } from "../types";
+
+export const rhymeOfTheDay: StatusBarMessageSprinkle = {
+  id: "rhyme-of-the-day",
+  kind: "status-bar-message",
+  author: "openchaos",
+  message:
+    "Sprinkles arrive in 5 minutes plus a rhyme — chase a small contribution any time.",
+};

--- a/src/sprinkles/seeds/sparkle-trail.ts
+++ b/src/sprinkles/seeds/sparkle-trail.ts
@@ -1,0 +1,10 @@
+import type { CursorTrailSprinkle } from "../types";
+
+export const sparkleTrail: CursorTrailSprinkle = {
+  id: "sparkle-trail",
+  kind: "cursor-trail",
+  author: "openchaos",
+  glyphs: ["✨", "✧", "✦", "·"],
+  fadeMs: 600,
+  throttleMs: 70,
+};

--- a/src/sprinkles/types.ts
+++ b/src/sprinkles/types.ts
@@ -1,0 +1,44 @@
+import type { ComponentType } from "react";
+import type { RouteGroup } from "@/lib/chaos-router";
+
+export type SprinkleKind =
+  | "terminal-command"
+  | "status-bar-message"
+  | "cursor-trail"
+  | "page-load-cameo";
+
+interface SprinkleBase<K extends SprinkleKind> {
+  id: string;
+  kind: K;
+  author: string;
+  incompatibleThemes?: readonly RouteGroup[];
+}
+
+export interface TerminalCommandSprinkle extends SprinkleBase<"terminal-command"> {
+  keyword: string;
+  response: string | readonly string[];
+}
+
+export interface StatusBarMessageSprinkle extends SprinkleBase<"status-bar-message"> {
+  message: string;
+  weight?: number;
+}
+
+export interface CursorTrailSprinkle extends SprinkleBase<"cursor-trail"> {
+  glyphs: readonly string[];
+  fadeMs?: number;
+  throttleMs?: number;
+}
+
+export interface PageLoadCameoSprinkle extends SprinkleBase<"page-load-cameo"> {
+  Component: ComponentType;
+  durationMs?: number;
+}
+
+export type Sprinkle =
+  | TerminalCommandSprinkle
+  | StatusBarMessageSprinkle
+  | CursorTrailSprinkle
+  | PageLoadCameoSprinkle;
+
+export type SprinkleOfKind<K extends SprinkleKind> = Extract<Sprinkle, { kind: K }>;

--- a/src/sprinkles/useSprinklesEnabled.ts
+++ b/src/sprinkles/useSprinklesEnabled.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useSprinklesEnabled(): boolean {
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("sprinkles") === "off") {
+        setEnabled(false);
+      }
+    } catch {
+      // SSR / non-browser — leave enabled
+    }
+  }, []);
+
+  return enabled;
+}


### PR DESCRIPTION
## Summary

Adds a small-contribution surface ("sprinkles") so drive-by visitors can leave their mark without committing to a full theme build. **"5 minutes + a rhyme."**

Four sprinkle kinds, each with its own tiny schema:

- **`terminal-command`** — pure data; merged into `ChaosTerminal`'s command table.
- **`status-bar-message`** — pure data; spliced into `StatusBar` rotation (optional `weight`).
- **`cursor-trail`** — glyph array; `CursorTrail` picks one compatible trail at random per page load.
- **`page-load-cameo`** — a React component; rendered briefly on mount by a global slot.

### What's in the box

- `src/sprinkles/` — discriminated-union types, registry (single source of truth, no auto-discovery), pure compatibility filter, `?sprinkles=off` escape hatch, page-load slot.
- Thin host integrations in `ChaosTerminal`, `CursorTrail`, `StatusBar`.
- `<Sprinkles kind="page-load" />` added to all four theme layouts.
- One seed per kind (chaos-fortune, rhyme-of-the-day, sparkle-trail, entry-firework) acting as smoke tests for each host.
- `ThemePath` extended to include `vaporwave`; vaporwave layout now wraps `ThemePathProvider` so compat filtering works there too.
- `SPRINKLES.md` contribution guide.

### Compatibility

Sprinkles default to compatible with all themes; a sprinkle declares `incompatibleThemes` to exclude specific ones. Honors the 5-minute promise — contributors don't have to study four themes before submitting.

### PR rules — unchanged

Rhyming title, CI must pass, 10-vote threshold, conflict-free. Sprinkle PRs go through the same gauntlet as any other.

## Test plan

- [x] `npm run build` passes
- [x] Open `/ascii`, `/web2`, `/newspaper`, `/vaporwave` and confirm the entry firework cameo plays on mount
- [x] In `/ascii` or `/web2`, open the terminal (`~`), type `sprinkle`, see chaos-fortune response
- [x] In `/web2`, wait through the status bar rotation, confirm the rhyme-of-the-day appears
- [x] In any theme, move the cursor; confirm sparkle glyphs trail (random per page load)
- [x] Append `?sprinkles=off` to any theme URL and confirm sprinkles are suppressed