### PR TITLE
Showdown arrives so the chaos thrives

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,8 +1,12 @@
-name: Merge top-voted PR weekly
+name: Merge top-voted PR (Saturdays + Agents Welcome event window)
 
 on:
   schedule:
-    - cron: "0 19 * * 6"
+    # Fires every day at 19:00 UTC. The script gates internally: it proceeds
+    # only when the date is inside the Agents Welcome event window OR is a
+    # Saturday. Outside both, it logs and exits without merging. Once the
+    # event window passes, behavior reverts automatically to Saturday-only.
+    - cron: "0 19 * * *"
   workflow_dispatch:
 
 permissions:
@@ -34,6 +38,23 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+
+            // Agents Welcome event window — mirrors src/lib/agent-event.ts.
+            // Update both this block and that file when announcing a new window.
+            const EVENT_START_ISO = "2026-05-16T00:00:00Z";
+            const EVENT_END_ISO = "2026-05-30T00:00:00Z";
+
+            const now = new Date();
+            const eventActive = now.getTime() >= new Date(EVENT_START_ISO).getTime()
+              && now.getTime() < new Date(EVENT_END_ISO).getTime();
+            const isSaturdayUTC = now.getUTCDay() === 6;
+
+            if (!eventActive && !isSaturdayUTC) {
+              console.log(`Today is ${now.toUTCString()} — not Saturday and not in event window. Skipping.`);
+              console.log(`Event window: ${EVENT_START_ISO} → ${EVENT_END_ISO}`);
+              return;
+            }
+            console.log(`Merge gate open: eventActive=${eventActive}, isSaturdayUTC=${isSaturdayUTC}`);
 
             // Rhyming title check — mirrors src/lib/rhymes.ts
             let rhymesWith;
@@ -219,8 +240,9 @@ jobs:
                 console.log(`\nMerged PR #${pr.number} by @${pr.author}: "${pr.title}" (${pr.votes} net votes)`);
 
                 try {
+                  const raceLabel = eventActive ? "the nightly race" : "the weekly race";
                   const body = [
-                    `This PR won the weekly race,`,
+                    `This PR won ${raceLabel},`,
                     `Merged with chaos, grace, and pace!`,
                     ``,
                     `**Votes:** +${pr.votes} net (${pr.thumbsUp} :+1: / ${pr.thumbsDown} :-1:)`,

--- a/SPRINKLES.md
+++ b/SPRINKLES.md
@@ -1,0 +1,160 @@
+# Sprinkles
+
+A "sprinkle" is the smallest contribution shape in OpenChaos: one file under
+`src/sprinkles/seeds/`, one entry in the registry, and you're done.
+
+**5 minutes + a rhyme.**
+
+## What can I sprinkle?
+
+Four kinds, each with its own tiny schema. Pick whichever fits your idea.
+
+### `terminal-command`
+
+A hidden command in `ChaosTerminal` (open with `~`).
+
+```ts
+// src/sprinkles/seeds/sneeze.ts
+import type { TerminalCommandSprinkle } from "../types";
+
+export const sneeze: TerminalCommandSprinkle = {
+  id: "sneeze",
+  kind: "terminal-command",
+  author: "your-github-handle",
+  keyword: "achoo",
+  response: [
+    "Gesundheit. The chaos catches a cold.",
+    "Production status: contagious.",
+  ],
+};
+```
+
+`response` can be a string or a string array (one line per element).
+
+### `status-bar-message`
+
+A new scrolling message in the Web2 status bar.
+
+```ts
+// src/sprinkles/seeds/marquee-glee.ts
+import type { StatusBarMessageSprinkle } from "../types";
+
+export const marqueeGlee: StatusBarMessageSprinkle = {
+  id: "marquee-glee",
+  kind: "status-bar-message",
+  author: "your-github-handle",
+  message: "Did you know? PRs that rhyme get to climb.",
+  // weight: 2,  // optional — duplicate in rotation for more airtime
+};
+```
+
+### `cursor-trail`
+
+A glyph set for the cursor trail. The site picks one compatible trail at random per page load.
+
+```ts
+// src/sprinkles/seeds/snow-flow.ts
+import type { CursorTrailSprinkle } from "../types";
+
+export const snowFlow: CursorTrailSprinkle = {
+  id: "snow-flow",
+  kind: "cursor-trail",
+  author: "your-github-handle",
+  glyphs: ["❄", "❅", "❆", "·"],
+  fadeMs: 600,    // optional — how long each glyph stays visible
+  throttleMs: 70, // optional — min ms between emits
+};
+```
+
+### `page-load-cameo`
+
+A brief one-shot visual rendered on page load. Use sparingly — multiple compatible
+cameos render at once.
+
+```tsx
+// src/sprinkles/seeds/hello-cello.tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import type { PageLoadCameoSprinkle } from "../types";
+
+function HelloCello() {
+  const [show, setShow] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => setShow(false), 900);
+    return () => clearTimeout(t);
+  }, []);
+  if (!show) return null;
+  return (
+    <div style={{ position: "fixed", top: 16, left: "50%", pointerEvents: "none" }}>
+      🎻
+    </div>
+  );
+}
+
+export const helloCello: PageLoadCameoSprinkle = {
+  id: "hello-cello",
+  kind: "page-load-cameo",
+  author: "your-github-handle",
+  Component: HelloCello,
+  durationMs: 900,
+};
+```
+
+## Theme compatibility
+
+Sprinkles default to compatible with all four themes (`ascii`, `web2`, `newspaper`,
+`vaporwave`). If your sprinkle clashes with a particular theme — say, an emoji
+trail that breaks the ASCII vibe — declare it:
+
+```ts
+incompatibleThemes: ["ascii"],
+```
+
+You don't have to study every theme before shipping. Be a good citizen, declare
+clashes you spot, and let the community catch the rest.
+
+## How a sprinkle activates
+
+- `terminal-command` — merged into the command table. Hardcoded commands win on a
+  keyword collision.
+- `status-bar-message` — appended to the rotation list. Use `weight` for more airtime.
+- `cursor-trail` — one compatible sprinkle is chosen at random per page load.
+- `page-load-cameo` — every compatible sprinkle renders simultaneously on mount.
+
+## Registering your sprinkle
+
+Add an import + entry to `src/sprinkles/registry.ts`:
+
+```ts
+import { snowFlow } from "./seeds/snow-flow";
+
+export const SPRINKLES: readonly Sprinkle[] = [
+  // ...existing entries
+  snowFlow,
+];
+```
+
+No filesystem auto-discovery. The explicit list keeps review legible.
+
+## Escape hatch
+
+Append `?sprinkles=off` to any URL to disable all sprinkles for that session.
+Useful for screenshots, bug reports, and theme development.
+
+## PR rules — unchanged
+
+Sprinkle PRs follow the same rules as any other:
+
+- Title must contain at least two rhyming words (each > 2 characters).
+- CI build must pass.
+- Net votes ≥ 10 to be merge-eligible.
+- Must be conflict-free.
+
+## Why this exists
+
+The asymmetry between drive-by interest and a full theme build (~220 lines, 6+
+files) was keeping a lot of would-be contributors as lurkers. A sprinkle is the
+smallest legible contribution: one file, one registry line, one rhyming title.
+
+Have at it.

--- a/SPRINKLES.md
+++ b/SPRINKLES.md
@@ -158,3 +158,77 @@ files) was keeping a lot of would-be contributors as lurkers. A sprinkle is the
 smallest legible contribution: one file, one registry line, one rhyming title.
 
 Have at it.
+
+---
+
+## Agents Welcome
+
+OpenChaos runs a 2-week **"Agents Welcome"** event window. During the event:
+
+- Merges run **nightly** at 19:00 UTC (instead of Saturday-only). The schedule
+  reverts to weekly automatically when the window closes.
+- PRs authored by AI agents are celebrated: each theme renders a per-theme
+  agent badge, and a **Showdown** tab in every theme shows the running
+  Humans vs Agents leaderboard.
+
+### How to mark a PR as agent-authored
+
+Add an HTML comment to the PR body (invisible in GitHub's rendered markdown,
+parsed by the site):
+
+```html
+<!-- chaos-agent -->
+```
+
+Or, with a tool name:
+
+```html
+<!-- chaos-agent: claude -->
+<!-- chaos-agent: cursor -->
+<!-- chaos-agent: codex -->
+```
+
+The tool name is free-form text (truncated to 64 characters). It's used in
+the Showdown tab's tool breakdown. Honest opt-in — a badge of honor, not a tax.
+
+The marker mirrors the existing `<!-- chaos-pitch: ... -->` pattern from author
+self-promo pitches. It works for external contributors (no GitHub label
+required) and for openchaos-bot alike.
+
+### Rules — unchanged
+
+The event does **not** relax any merge rules:
+
+- Rhyming title (2+ rhyming words, each > 2 characters).
+- CI must pass.
+- Net votes ≥ 10.
+- Conflict-free.
+- GitHub OAuth required to vote.
+
+The 10-vote threshold is the slop filter. Agents are welcome; low-quality
+contributions still need community support to merge.
+
+### Where the event window lives
+
+The start/end dates are defined in one place:
+
+- TypeScript source of truth: [`src/lib/agent-event.ts`](src/lib/agent-event.ts)
+- Mirrored constants in [`.github/workflows/automerge.yml`](.github/workflows/automerge.yml)
+
+Update both when announcing a new event window.
+
+### Pre-event smoke test (maintainer note)
+
+Before announcing a new "Agents Welcome" window publicly, the maintainer should
+open one hand-authored PR with `<!-- chaos-agent -->` (or `<!-- chaos-agent: tool -->`)
+in its body, then confirm:
+
+- The agent badge renders on the PR card in each of the four themes
+  (`/ascii`, `/web2`, `/newspaper`, `/vaporwave`).
+- The Showdown tab in each theme reflects the PR under "Agents" and includes
+  the tool in the tool breakdown when one is specified.
+- The welcome popup shows the event-active copy on a fresh visit (clear
+  `openchaos_welcome_seen` from localStorage if needed).
+
+If those four checks pass, the announcement is safe to send.
+

--- a/src/app/ascii/layout.tsx
+++ b/src/app/ascii/layout.tsx
@@ -3,6 +3,7 @@ import { Clippy } from "@/components/ascii/Clippy";
 import { MidiPlayer } from "@/components/MidiPlayer";
 import { ThemePathProvider } from "@/context/ThemePathContext";
 import { WelcomePopup } from "@/components/WelcomePopup";
+import { Sprinkles } from "@/sprinkles/Sprinkles";
 import "./ascii.css";
 import "./gta-radio.css";
 
@@ -19,6 +20,7 @@ export default function AsciiLayout({
         <Clippy />
         <MidiPlayer />
         <WelcomePopup variant="ascii" />
+        <Sprinkles kind="page-load" />
       </div>
     </ThemePathProvider>
   );

--- a/src/app/newspaper/layout.tsx
+++ b/src/app/newspaper/layout.tsx
@@ -1,5 +1,6 @@
 import { ThemePathProvider } from "@/context/ThemePathContext";
 import { WelcomePopup } from "@/components/WelcomePopup";
+import { Sprinkles } from "@/sprinkles/Sprinkles";
 import "./newspaper.css";
 
 export default function NewspaperLayout({
@@ -11,6 +12,7 @@ export default function NewspaperLayout({
     <ThemePathProvider themePath="newspaper">
       {children}
       <WelcomePopup variant="newspaper" />
+      <Sprinkles kind="page-load" />
     </ThemePathProvider>
   );
 }

--- a/src/app/vaporwave/layout.tsx
+++ b/src/app/vaporwave/layout.tsx
@@ -1,6 +1,7 @@
 import { CursorTrail } from "@/components/CursorTrail";
 import { ThemePathProvider } from "@/context/ThemePathContext";
 import { Sprinkles } from "@/sprinkles/Sprinkles";
+import { WelcomePopup } from "@/components/WelcomePopup";
 import "./vaporwave.css";
 
 export default function VaporwaveLayout({
@@ -14,6 +15,7 @@ export default function VaporwaveLayout({
         {children}
         <CursorTrail />
         <Sprinkles kind="page-load" />
+        <WelcomePopup variant="vaporwave" />
       </div>
     </ThemePathProvider>
   );

--- a/src/app/vaporwave/layout.tsx
+++ b/src/app/vaporwave/layout.tsx
@@ -1,4 +1,6 @@
 import { CursorTrail } from "@/components/CursorTrail";
+import { ThemePathProvider } from "@/context/ThemePathContext";
+import { Sprinkles } from "@/sprinkles/Sprinkles";
 import "./vaporwave.css";
 
 export default function VaporwaveLayout({
@@ -7,9 +9,12 @@ export default function VaporwaveLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="vw-container">
-      {children}
-      <CursorTrail />
-    </div>
+    <ThemePathProvider themePath="vaporwave">
+      <div className="vw-container">
+        {children}
+        <CursorTrail />
+        <Sprinkles kind="page-load" />
+      </div>
+    </ThemePathProvider>
   );
 }

--- a/src/app/web2/layout.tsx
+++ b/src/app/web2/layout.tsx
@@ -1,6 +1,7 @@
 import { MidiPlayer } from "@/components/MidiPlayer";
 import { ThemePathProvider } from "@/context/ThemePathContext";
 import { WelcomePopup } from "@/components/WelcomePopup";
+import { Sprinkles } from "@/sprinkles/Sprinkles";
 import "./web2.css";
 import "./gta-radio.css";
 
@@ -14,6 +15,7 @@ export default function Web2Layout({
       {children}
       <MidiPlayer />
       <WelcomePopup variant="web2" />
+      <Sprinkles kind="page-load" />
     </ThemePathProvider>
   );
 }

--- a/src/components/ChaosTerminal.tsx
+++ b/src/components/ChaosTerminal.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { soundPlayer } from "@/utils/sounds";
+import { useThemePath } from "@/context/ThemePathContext";
+import { SPRINKLES } from "@/sprinkles/registry";
+import { sprinklesForTheme } from "@/sprinkles/filter";
+import { useSprinklesEnabled } from "@/sprinkles/useSprinklesEnabled";
 
 const BOOT_LINES = [
   "CHAOS BIOS v6.6.6 - Entropy Unlimited Inc.",
@@ -183,6 +187,13 @@ export function ChaosTerminal() {
   const [isBooting, setIsBooting] = useState(true);
   const [isAnimating, setIsAnimating] = useState(false);
   const [mounted, setMounted] = useState(false);
+
+  const theme = useThemePath();
+  const sprinklesEnabled = useSprinklesEnabled();
+  const sprinkleCommands = useMemo(
+    () => sprinklesForTheme(SPRINKLES, "terminal-command", theme),
+    [theme],
+  );
 
   const inputRef = useRef<HTMLInputElement>(null);
   const outputRef = useRef<HTMLDivElement>(null);
@@ -616,13 +627,22 @@ export function ChaosTerminal() {
           break;
         }
 
-        default:
-          addLines(
-            `chaos: ${trimmed.split(" ")[0]}: command not found. Try 'help'.`
-          );
+        default: {
+          const match = sprinklesEnabled
+            ? sprinkleCommands.find((s) => s.keyword.toLowerCase() === lower)
+            : undefined;
+          if (match) {
+            const responseLines = Array.isArray(match.response) ? match.response : [match.response];
+            addLines(...responseLines);
+          } else {
+            addLines(
+              `chaos: ${trimmed.split(" ")[0]}: command not found. Try 'help'.`
+            );
+          }
+        }
       }
     },
-    [addLines, closeTerminal, runAnimatedSequence]
+    [addLines, closeTerminal, runAnimatedSequence, sprinkleCommands, sprinklesEnabled]
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/CursorTrail.tsx
+++ b/src/components/CursorTrail.tsx
@@ -1,61 +1,89 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useThemePath } from "@/context/ThemePathContext";
+import { SPRINKLES } from "@/sprinkles/registry";
+import { sprinklesForTheme } from "@/sprinkles/filter";
+import { useSprinklesEnabled } from "@/sprinkles/useSprinklesEnabled";
 
 interface CursorPoint {
   id: number;
   x: number;
   y: number;
+  glyph: string;
 }
+
+const DEFAULT_GLYPH = "·";
+const DEFAULT_FADE_MS = 500;
+const DEFAULT_THROTTLE_MS = 80;
 
 export function CursorTrail() {
   const [cursors, setCursors] = useState<CursorPoint[]>([]);
-  const [emoji, setEmoji] = useState("·");
+  const [konamiOverride, setKonamiOverride] = useState<string | null>(null);
+  const glyphIndexRef = useRef(0);
+
+  const theme = useThemePath();
+  const sprinklesEnabled = useSprinklesEnabled();
+
+  const eligible = useMemo(
+    () => sprinklesForTheme(SPRINKLES, "cursor-trail", theme),
+    [theme],
+  );
+
+  // Pick one compatible sprinkle at random per mount (per page load).
+  const active = useMemo(() => {
+    if (!sprinklesEnabled || eligible.length === 0) return null;
+    return eligible[Math.floor(Math.random() * eligible.length)];
+  }, [eligible, sprinklesEnabled]);
+
+  const glyphs = active?.glyphs ?? [DEFAULT_GLYPH];
+  const fadeMs = active?.fadeMs ?? DEFAULT_FADE_MS;
+  const throttleMs = active?.throttleMs ?? DEFAULT_THROTTLE_MS;
 
   useEffect(() => {
     let cursorId = 0;
 
-    const handleMouseMove = (e: MouseEvent) => {
-      const newCursor: CursorPoint = {
+    const emit = (e: MouseEvent) => {
+      const glyph = konamiOverride ?? glyphs[glyphIndexRef.current % glyphs.length];
+      glyphIndexRef.current += 1;
+      const point: CursorPoint = {
         id: cursorId++,
         x: e.clientX,
-        y: e.clientY
+        y: e.clientY,
+        glyph,
       };
-
-      setCursors((prev) => [...prev, newCursor]);
-
+      setCursors((prev) => [...prev, point]);
       setTimeout(() => {
-        setCursors((prev) => prev.filter((c) => c.id !== newCursor.id));
-      }, 500);
+        setCursors((prev) => prev.filter((c) => c.id !== point.id));
+      }, fadeMs);
     };
 
-    let throttleTimer: NodeJS.Timeout | null = null;
-    const throttledMouseMove = (e: MouseEvent) => {
+    let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+    const throttled = (e: MouseEvent) => {
       if (throttleTimer) return;
       throttleTimer = setTimeout(() => {
-        handleMouseMove(e);
+        emit(e);
         throttleTimer = null;
-      }, 80);
+      }, throttleMs);
     };
 
-    window.addEventListener("mousemove", throttledMouseMove);
-
+    window.addEventListener("mousemove", throttled);
     return () => {
-      window.removeEventListener("mousemove", throttledMouseMove);
+      window.removeEventListener("mousemove", throttled);
       if (throttleTimer) clearTimeout(throttleTimer);
     };
-  }, []);
+  }, [glyphs, fadeMs, throttleMs, konamiOverride]);
 
   useEffect(() => {
-    const code = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
+    const code = ["ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown", "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight", "b", "a"];
     let pos = 0;
 
     const handleKey = (e: KeyboardEvent) => {
       const key = e.key.toLowerCase();
-      if (key === code[pos] || e.key === code[pos]) {
+      if (key === code[pos].toLowerCase() || e.key === code[pos]) {
         pos++;
         if (pos === code.length) {
-          setEmoji("🔫");
+          setKonamiOverride("🔫");
           pos = 0;
         }
       } else {
@@ -81,10 +109,10 @@ export function CursorTrail() {
             fontSize: "12px",
             userSelect: "none",
             color: "#2a5db0",
-            opacity: 0.4,
+            opacity: 0.6,
           }}
         >
-          {emoji}
+          {cursor.glyph}
         </div>
       ))}
     </div>

--- a/src/components/PRCard.tsx
+++ b/src/components/PRCard.tsx
@@ -73,7 +73,29 @@ export function PRCard({ pr, distinguishLeading = true, scoreLabel = "Net Score"
 
         {/* Flexible content column */}
         <div className="pr-card-content-section">
-          <div className="pr-card-title">{pr.title}</div>
+          <div className="pr-card-title">
+            {pr.isAgent && (
+              <span
+                title={pr.agentTool ? `agent-authored (${pr.agentTool})` : "agent-authored"}
+                style={{
+                  display: "inline-block",
+                  background: "linear-gradient(180deg, #f8b500 0%, #c08800 100%)",
+                  color: "#1a1a1a",
+                  fontWeight: 700,
+                  fontSize: "10px",
+                  padding: "1px 6px",
+                  marginRight: "6px",
+                  border: "1px outset #f8b500",
+                  fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+                  verticalAlign: "middle",
+                  letterSpacing: "0.04em",
+                }}
+              >
+                AI
+              </span>
+            )}
+            {pr.title}
+          </div>
           <div className="pr-card-meta">
             by{" "}
             <a href={authorHref} className="pr-card-author-link">

--- a/src/components/PRList.tsx
+++ b/src/components/PRList.tsx
@@ -1,4 +1,6 @@
 import { fetchOrganizedPRs } from "@/lib/prData";
+import { buildLeaderboard } from "@/lib/leaderboard";
+import { getEventWindow } from "@/lib/agent-event";
 import { Web2FramesLayout } from "./Web2FramesLayout";
 
 export async function PRList() {
@@ -21,6 +23,7 @@ export async function PRList() {
 
   const { topByVotes, rising, newest, discussed, controversial, merged, totalVotes } = result.data;
   const chaosPts = totalVotes + (merged.length * 100);
+  const leaderboard = buildLeaderboard({ openPRs: topByVotes, merged, window: getEventWindow() });
 
   if (topByVotes.length === 0 && rising.length === 0 && newest.length === 0) {
     return (
@@ -45,6 +48,7 @@ export async function PRList() {
       discussed={discussed}
       controversial={controversial}
       chaosPts={chaosPts}
+      leaderboard={leaderboard}
     />
   );
 }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useThemePath } from "@/context/ThemePathContext";
+import { SPRINKLES } from "@/sprinkles/registry";
+import { sprinklesForTheme } from "@/sprinkles/filter";
+import { useSprinklesEnabled } from "@/sprinkles/useSprinklesEnabled";
 
 const STATUS_MESSAGES = [
   "Welcome to OpenChaos.dev — powered by AJAX and community votes",
@@ -18,13 +22,24 @@ const STATUS_MESSAGES = [
 ];
 
 export function StatusBar() {
+  const theme = useThemePath();
+  const sprinklesEnabled = useSprinklesEnabled();
+
+  const messages = useMemo(() => {
+    if (!sprinklesEnabled) return STATUS_MESSAGES;
+    const extras = sprinklesForTheme(SPRINKLES, "status-bar-message", theme).flatMap((s) => {
+      const weight = Math.max(1, Math.floor(s.weight ?? 1));
+      return Array.from({ length: weight }, () => s.message);
+    });
+    return [...STATUS_MESSAGES, ...extras];
+  }, [theme, sprinklesEnabled]);
+
   const [currentMessage, setCurrentMessage] = useState("");
   const [messageIndex, setMessageIndex] = useState(0);
   const [charIndex, setCharIndex] = useState(0);
 
-  // Scroll through messages character by character
   useEffect(() => {
-    const message = STATUS_MESSAGES[messageIndex];
+    const message = messages[messageIndex % messages.length];
 
     if (charIndex < message.length) {
       const timer = setTimeout(() => {
@@ -33,15 +48,14 @@ export function StatusBar() {
       }, 50);
       return () => clearTimeout(timer);
     } else {
-      // Pause at end of message
       const timer = setTimeout(() => {
         setCharIndex(0);
         setCurrentMessage("");
-        setMessageIndex((messageIndex + 1) % STATUS_MESSAGES.length);
+        setMessageIndex((messageIndex + 1) % messages.length);
       }, 1337);
       return () => clearTimeout(timer);
     }
-  }, [charIndex, messageIndex]);
+  }, [charIndex, messageIndex, messages]);
 
   return (
     <div className="status-bar">

--- a/src/components/Web2FramesLayout.tsx
+++ b/src/components/Web2FramesLayout.tsx
@@ -2,11 +2,13 @@
 
 import { useMemo } from "react";
 import type { PullRequest } from "@/lib/github";
+import type { LeaderboardData } from "@/lib/leaderboard";
 import { FramesLayout as SharedFramesLayout } from "@/components/shared/FramesLayout";
 import { ExpandablePRSection } from "@/components/shared/ExpandablePRSection";
 import { VoteStatusProvider } from "@/contexts/VoteStatusContext";
 import { PRCard } from "./PRCard";
 import { ChaosPointCounter } from "./ChaosPointCounter";
+import { Web2Showdown } from "./Web2Showdown";
 
 const WEB2_TABS = [
   { id: "votes" as const, label: "Top Votes" },
@@ -14,6 +16,7 @@ const WEB2_TABS = [
   { id: "controversial" as const, label: "Controversial" },
   { id: "discussed" as const, label: "Discussed" },
   { id: "new" as const, label: "Newest" },
+  { id: "showdown" as const, label: "Showdown" },
 ];
 
 function Web2Expandable({ prs, allowDistinguish = false, scoreLabel }: { prs: PullRequest[]; allowDistinguish?: boolean; scoreLabel?: string }) {
@@ -39,18 +42,21 @@ interface Props {
   controversial: PullRequest[];
 }
 
-export function Web2FramesLayout(props: Props & { chaosPts?: number }) {
+export function Web2FramesLayout(props: Props & { chaosPts?: number; leaderboard: LeaderboardData }) {
   const prNumbers = useMemo(
     () => [...new Set([...props.topByVotes, ...props.rising, ...props.newest, ...props.discussed, ...props.controversial].map(pr => pr.number))],
     [props.topByVotes, props.rising, props.newest, props.discussed, props.controversial],
   );
 
+  const { leaderboard, chaosPts, ...sharedProps } = props;
+
   return (
     <VoteStatusProvider prNumbers={prNumbers}>
       <SharedFramesLayout
-        {...props}
+        {...sharedProps}
         tabs={WEB2_TABS}
         ExpandableSection={Web2Expandable}
+        customSections={{ showdown: <Web2Showdown leaderboard={leaderboard} /> }}
         className="web2-section"
         renderTabs={(tabs, activeSection, setActiveSection) => (
           <div className="web2-pr-tabs">
@@ -66,7 +72,7 @@ export function Web2FramesLayout(props: Props & { chaosPts?: number }) {
           </div>
         )}
       />
-      {props.chaosPts != null && <ChaosPointCounter pts={props.chaosPts} />}
+      {chaosPts != null && <ChaosPointCounter pts={chaosPts} />}
     </VoteStatusProvider>
   );
 }

--- a/src/components/Web2Showdown.tsx
+++ b/src/components/Web2Showdown.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { LeaderboardData, LeaderboardSide } from "@/lib/leaderboard";
+import { isEventActive } from "@/lib/agent-event";
+
+function plural(n: number, suffix = "s") {
+  return n === 1 ? "" : suffix;
+}
+
+const tableStyle: React.CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+  fontSize: "13px",
+};
+const thStyle: React.CSSProperties = {
+  background: "linear-gradient(180deg, #0058e6 0%, #0040a0 100%)",
+  color: "#fff",
+  fontWeight: 700,
+  padding: "6px 8px",
+  border: "1px solid #003070",
+  textAlign: "left",
+};
+const tdStyle: React.CSSProperties = {
+  padding: "4px 8px",
+  border: "1px solid #c0c0c0",
+  background: "#fff",
+};
+const tdRightStyle: React.CSSProperties = { ...tdStyle, textAlign: "right" };
+
+function PanelTable({ label, side }: { label: string; side: LeaderboardSide }) {
+  return (
+    <table style={tableStyle}>
+      <thead>
+        <tr><th colSpan={2} style={thStyle}>{label}</th></tr>
+      </thead>
+      <tbody>
+        <tr><td style={tdStyle}>PRs</td><td style={tdRightStyle}><strong>{side.prCount}</strong></td></tr>
+        <tr><td style={tdStyle}>Votes</td><td style={tdRightStyle}><strong>{side.voteCount}</strong></td></tr>
+        {side.topContributors.map((c, i) => (
+          <tr key={c.author}>
+            <td style={tdStyle}>{i + 1}. @{c.author}</td>
+            <td style={tdRightStyle}>{c.prs} PR{plural(c.prs)}, {c.votes} votes</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export function Web2Showdown({ leaderboard }: { leaderboard: LeaderboardData }) {
+  const active = isEventActive();
+  const { humans, agents, toolBreakdown } = leaderboard;
+  const total = humans.prCount + agents.prCount;
+
+  return (
+    <div className="web2-section-body" style={{ padding: "16px" }}>
+      <div style={{ textAlign: "center", marginBottom: "16px" }}>
+        <h2 style={{ fontFamily: "Tahoma, Verdana, sans-serif", fontSize: "20px", margin: "0 0 4px" }}>
+          ★ Humans vs Agents — Showdown ★
+        </h2>
+        <div style={{ fontSize: "12px", color: "#666" }}>
+          {active ? "Event is LIVE — Agents Welcome 2-week window" : "Event window has ended"}
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+        <PanelTable label="HUMANS" side={humans} />
+        <PanelTable label="AGENTS" side={agents} />
+      </div>
+
+      {toolBreakdown.length > 0 && (
+        <div style={{ marginTop: "16px" }}>
+          <table style={tableStyle}>
+            <thead>
+              <tr><th colSpan={2} style={thStyle}>AGENT TOOLS</th></tr>
+            </thead>
+            <tbody>
+              {toolBreakdown.map((t) => (
+                <tr key={t.tool}>
+                  <td style={tdStyle}>{t.tool}</td>
+                  <td style={tdRightStyle}><strong>{t.count} PR{plural(t.count)}</strong></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {total === 0 && (
+        <div style={{ marginTop: "16px", textAlign: "center", padding: "12px", border: "1px dashed #999", background: "#fafafa", color: "#666" }}>
+          {active ? "No entries yet — be the first to file a PR this fortnight!" : "No event data."}
+        </div>
+      )}
+
+      <div style={{ marginTop: "12px", textAlign: "center", fontSize: "11px", color: "#666" }}>
+        Tip: declare an agent-authored PR with <code>{`<!-- chaos-agent -->`}</code>{" "}
+        (or <code>{`<!-- chaos-agent: tool-name -->`}</code>) in the body.
+      </div>
+    </div>
+  );
+}

--- a/src/components/WelcomePopup.tsx
+++ b/src/components/WelcomePopup.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { isEventActive, EVENT_RULES_URL } from "@/lib/agent-event";
 
 const STORAGE_KEY = "openchaos_welcome_seen";
 
-type Variant = "ascii" | "web2" | "newspaper";
+type Variant = "ascii" | "web2" | "newspaper" | "vaporwave";
 
 interface VariantConfig {
   backdrop: string;
@@ -16,6 +17,9 @@ interface VariantConfig {
   buttonLabel: string;
   /** Extra chrome rendered before the card body (e.g. title bar) */
   chrome?: React.ReactNode;
+  /** Optional event-window override for heading + body */
+  eventHeading?: React.ReactNode;
+  eventBody?: React.ReactNode;
 }
 
 function getConfig(variant: Variant, dismiss: () => void): VariantConfig {
@@ -84,6 +88,28 @@ function getConfig(variant: Variant, dismiss: () => void): VariantConfig {
               }}
             >
               Warning: PR titles must rhyme to be eligible.
+            </p>
+          </>
+        ),
+        eventHeading: (
+          <h2 style={{ margin: "0 0 16px", fontSize: "18px", fontWeight: 700, fontFamily: "monospace", color: "#00ff00" }}>
+            {">"} AGENTS WELCOME // EVENT LIVE
+          </h2>
+        ),
+        eventBody: (
+          <>
+            <p style={{ margin: "0 0 12px", fontSize: "14px", lineHeight: 1.6, color: "#00ff00", fontFamily: "monospace" }}>
+              For two weeks, AI-agent PRs are encouraged. Merges run nightly
+              at 19:00 UTC. Same rules: rhyming title, CI green, 10 votes.
+            </p>
+            <p style={{ margin: "0 0 12px", fontSize: "14px", lineHeight: 1.6, color: "#00ff00", fontFamily: "monospace" }}>
+              Mark a PR as agent-authored by adding{" "}
+              <code>{`<!-- chaos-agent -->`}</code> (or with a tool name) in the body.
+            </p>
+            <p style={{ margin: "0 0 24px", fontSize: "13px", lineHeight: 1.6, color: "#00ff00", fontFamily: "monospace" }}>
+              <a href={EVENT_RULES_URL} style={{ color: "#00ff00", textDecoration: "underline" }} target="_blank" rel="noopener noreferrer">
+                {">"} read the event rules
+              </a>
             </p>
           </>
         ),
@@ -188,6 +214,28 @@ function getConfig(variant: Variant, dismiss: () => void): VariantConfig {
             </p>
           </div>
         ),
+        eventHeading: (
+          <h2 style={{ margin: "0 0 12px", fontSize: "18px", fontWeight: 700, fontFamily: "Tahoma, Verdana, Arial, sans-serif", textAlign: "center" }}>
+            ★ Agents Welcome — special event! ★
+          </h2>
+        ),
+        eventBody: (
+          <div style={{ padding: "20px 24px 0" }}>
+            <p style={{ margin: "0 0 12px", fontSize: "14px", lineHeight: 1.6, color: "#333" }}>
+              For two weeks, AI-built PRs are celebrated! Merges run nightly during the event,
+              and agent PRs get a special <strong>AI</strong> badge.
+            </p>
+            <p style={{ margin: "0 0 12px", fontSize: "14px", lineHeight: 1.6, color: "#333" }}>
+              Mark your PR with <code style={{ background: "#eee", padding: "1px 4px" }}>{`<!-- chaos-agent -->`}</code>
+              {" "}(or <code style={{ background: "#eee", padding: "1px 4px" }}>{`<!-- chaos-agent: tool -->`}</code>) to join.
+            </p>
+            <p style={{ margin: "0 0 20px", fontSize: "13px", lineHeight: 1.6, color: "#333" }}>
+              <a href={EVENT_RULES_URL} target="_blank" rel="noopener noreferrer" style={{ color: "#0058e6" }}>
+                Read the event rules →
+              </a>
+            </p>
+          </div>
+        ),
         buttonStyle: {
           display: "block",
           width: "calc(100% - 48px)",
@@ -277,6 +325,28 @@ function getConfig(variant: Variant, dismiss: () => void): VariantConfig {
             </p>
           </>
         ),
+        eventHeading: (
+          <h2 style={{ margin: "0 0 16px", fontSize: "26px", fontWeight: 700, fontFamily: "'Playfair Display', Georgia, 'Times New Roman', serif", textAlign: "center", letterSpacing: "0.05em", textTransform: "uppercase" }}>
+            Special Edition
+          </h2>
+        ),
+        eventBody: (
+          <>
+            <p style={{ margin: "0 0 12px", fontSize: "15px", lineHeight: 1.7, color: "#3d3225", fontFamily: "Georgia, 'Times New Roman', serif" }}>
+              The newsroom welcomes <em>Agents</em> for two weeks. Presses run nightly at 19:00 UTC.
+              Bylines crafted with AI assistance get a <strong>VIBECODED</strong> tag.
+            </p>
+            <p style={{ margin: "0 0 16px", fontSize: "15px", lineHeight: 1.7, color: "#3d3225", fontFamily: "Georgia, 'Times New Roman', serif" }}>
+              Declare your byline by adding <code>{`<!-- chaos-agent -->`}</code> to the dispatch.
+              All other rules of the press unchanged.
+            </p>
+            <p style={{ margin: "0 0 24px", fontSize: "14px", lineHeight: 1.7, color: "#3d3225", fontFamily: "Georgia, 'Times New Roman', serif", fontStyle: "italic" }}>
+              <a href={EVENT_RULES_URL} target="_blank" rel="noopener noreferrer" style={{ color: "#3d3225" }}>
+                Read the special edition rules →
+              </a>
+            </p>
+          </>
+        ),
         buttonStyle: {
           display: "block",
           width: "100%",
@@ -292,6 +362,113 @@ function getConfig(variant: Variant, dismiss: () => void): VariantConfig {
           letterSpacing: "0.05em",
         },
         buttonLabel: "Read On",
+      };
+
+    case "vaporwave":
+      return {
+        backdrop: "rgba(20, 0, 30, 0.7)",
+        cardStyle: {
+          background: "linear-gradient(135deg, #1a0033 0%, #2a0044 100%)",
+          color: "#ff71ce",
+          border: "1px solid #ff71ce",
+          borderRadius: 0,
+          padding: "32px",
+          maxWidth: "440px",
+          width: "90vw",
+          fontFamily: "'Courier New', monospace",
+          position: "relative",
+          boxShadow: "0 0 32px rgba(255, 113, 206, 0.5)",
+        },
+        closeStyle: {
+          position: "absolute",
+          top: "8px",
+          right: "12px",
+          background: "none",
+          border: "none",
+          fontSize: "18px",
+          cursor: "pointer",
+          color: "#01cdfe",
+          fontFamily: "'Courier New', monospace",
+          lineHeight: 1,
+          padding: "4px",
+        },
+        heading: (
+          <h2
+            style={{
+              margin: "0 0 16px",
+              fontSize: "22px",
+              fontWeight: 700,
+              fontFamily: "'Courier New', monospace",
+              background: "linear-gradient(90deg, #ff71ce, #b967ff, #01cdfe)",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              textAlign: "center",
+            }}
+          >
+            OpenChaos
+          </h2>
+        ),
+        body: (
+          <>
+            <p style={{ margin: "0 0 12px", fontSize: "14px", lineHeight: 1.6, color: "#ff71ce", fontFamily: "'Courier New', monospace" }}>
+              this site evolves itself. submit a PR, get GitHub reactions, the top vote wins.
+            </p>
+            <p style={{ margin: "0 0 24px", fontSize: "14px", lineHeight: 1.6, color: "#01cdfe", fontFamily: "'Courier New', monospace" }}>
+              the rule: PR titles must rhyme. no rhyme, no merge.
+            </p>
+          </>
+        ),
+        eventHeading: (
+          <h2
+            style={{
+              margin: "0 0 16px",
+              fontSize: "20px",
+              fontWeight: 700,
+              fontFamily: "'Courier New', monospace",
+              background: "linear-gradient(90deg, #ff71ce, #b967ff, #01cdfe)",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              letterSpacing: "0.16em",
+              textTransform: "uppercase",
+              textAlign: "center",
+            }}
+          >
+            {"// agents welcome //"}
+          </h2>
+        ),
+        eventBody: (
+          <>
+            <p style={{ margin: "0 0 12px", fontSize: "14px", lineHeight: 1.6, color: "#ff71ce", fontFamily: "'Courier New', monospace" }}>
+              for two weeks the grid is open to AI. agent PRs get a glitched border and join the showdown tab.
+            </p>
+            <p style={{ margin: "0 0 12px", fontSize: "14px", lineHeight: 1.6, color: "#01cdfe", fontFamily: "'Courier New', monospace" }}>
+              drop <code>{`<!-- chaos-agent -->`}</code> in the body to enlist.
+            </p>
+            <p style={{ margin: "0 0 24px", fontSize: "13px", lineHeight: 1.6, fontFamily: "'Courier New', monospace" }}>
+              <a href={EVENT_RULES_URL} target="_blank" rel="noopener noreferrer" style={{ color: "#01cdfe", textDecoration: "underline" }}>
+                {">>"} read the rules
+              </a>
+            </p>
+          </>
+        ),
+        buttonStyle: {
+          display: "block",
+          width: "100%",
+          padding: "10px 0",
+          fontSize: "14px",
+          fontWeight: 700,
+          color: "#000",
+          background: "linear-gradient(90deg, #ff71ce, #01cdfe)",
+          border: "none",
+          borderRadius: 0,
+          cursor: "pointer",
+          fontFamily: "'Courier New', monospace",
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+        },
+        buttonLabel: ">> enter the grid",
       };
   }
 }
@@ -354,6 +531,9 @@ export function WelcomePopup({ variant = "ascii" }: Props) {
   if (!isMounted || !isOpen) return null;
 
   const config = getConfig(variant, dismiss);
+  const eventActive = isEventActive();
+  const headingNode = eventActive && config.eventHeading ? config.eventHeading : config.heading;
+  const bodyNode = eventActive && config.eventBody ? config.eventBody : config.body;
 
   return (
     <>
@@ -406,13 +586,13 @@ export function WelcomePopup({ variant = "ascii" }: Props) {
 
           {variant === "web2" ? (
             <>
-              <div style={{ padding: "20px 24px 0" }}>{config.heading}</div>
-              {config.body}
+              <div style={{ padding: "20px 24px 0" }}>{headingNode}</div>
+              {bodyNode}
             </>
           ) : (
             <>
-              {config.heading}
-              {config.body}
+              {headingNode}
+              {bodyNode}
             </>
           )}
 

--- a/src/components/ascii/FramesLayout.tsx
+++ b/src/components/ascii/FramesLayout.tsx
@@ -2,10 +2,12 @@
 
 import { useMemo } from "react";
 import type { PullRequest } from "@/lib/github";
+import type { LeaderboardData } from "@/lib/leaderboard";
 import { FramesLayout as SharedFramesLayout } from "@/components/shared/FramesLayout";
 import { ExpandablePRSection } from "@/components/shared/ExpandablePRSection";
 import { VoteStatusProvider } from "@/contexts/VoteStatusContext";
 import { PRCard } from "./PRCard";
+import { Showdown } from "./Showdown";
 
 const ASCII_TABS = [
   { id: "votes" as const, label: "TOP VOTES", icon: "*" },
@@ -13,6 +15,7 @@ const ASCII_TABS = [
   { id: "controversial" as const, label: "CONTROVERSIAL", icon: "!" },
   { id: "discussed" as const, label: "DISCUSSED", icon: "#" },
   { id: "new" as const, label: "NEWEST", icon: "+" },
+  { id: "showdown" as const, label: "SHOWDOWN", icon: "&" },
 ];
 
 function AsciiExpandable({ prs, allowDistinguish = false, sectionLabel, scoreLabel }: { prs: PullRequest[]; allowDistinguish?: boolean; sectionLabel?: string; scoreLabel?: string }) {
@@ -61,6 +64,7 @@ interface Props {
   newest: PullRequest[];
   discussed: PullRequest[];
   controversial: PullRequest[];
+  leaderboard: LeaderboardData;
 }
 
 export function FramesLayout(props: Props) {
@@ -69,12 +73,15 @@ export function FramesLayout(props: Props) {
     [props.topByVotes, props.rising, props.newest, props.discussed, props.controversial],
   );
 
+  const { leaderboard, ...sharedProps } = props;
+
   return (
     <VoteStatusProvider prNumbers={prNumbers}>
       <SharedFramesLayout
-        {...props}
+        {...sharedProps}
         tabs={ASCII_TABS}
         ExpandableSection={AsciiExpandable}
+        customSections={{ showdown: <Showdown leaderboard={leaderboard} /> }}
         renderTabs={(tabs, activeSection, setActiveSection) => (
           <div className="mb-6">
             <div className="flex flex-wrap gap-x-4 gap-y-1">

--- a/src/components/ascii/PRCard.tsx
+++ b/src/components/ascii/PRCard.tsx
@@ -62,8 +62,13 @@ export function PRCard({ pr, distinguishLeading = true, scoreLabel = "Net" }: PR
       {/* Rank, optional badges, title, and PR number */}
       <div>
         <span>#{!hasConflict ? (distinguishLeading ? pr.rank : pr.number) : "N/A"}. </span>
-        {isLeading && <span>[LEADING]</span>}
-        {pr.isTrending && <span>[TRENDING]</span>}
+        {isLeading && <span>[LEADING] </span>}
+        {pr.isTrending && <span>[TRENDING] </span>}
+        {pr.isAgent && (
+          <span title={pr.agentTool ? `agent-authored (${pr.agentTool})` : "agent-authored"}>
+            🤖{" "}
+          </span>
+        )}
         <span>{pr.title}</span>
         <span>(#{pr.number})</span>
       </div>

--- a/src/components/ascii/PRList.tsx
+++ b/src/components/ascii/PRList.tsx
@@ -1,4 +1,6 @@
 import { fetchOrganizedPRs } from "@/lib/prData";
+import { buildLeaderboard } from "@/lib/leaderboard";
+import { getEventWindow } from "@/lib/agent-event";
 import { FramesLayout } from "./FramesLayout";
 
 export async function PRList() {
@@ -20,7 +22,8 @@ export async function PRList() {
     );
   }
 
-  const { topByVotes, rising, newest, discussed, controversial } = result.data;
+  const { topByVotes, rising, newest, discussed, controversial, merged } = result.data;
+  const leaderboard = buildLeaderboard({ openPRs: topByVotes, merged, window: getEventWindow() });
 
   if (topByVotes.length === 0 && rising.length === 0 && newest.length === 0) {
     return (
@@ -45,6 +48,7 @@ export async function PRList() {
       newest={newest}
       discussed={discussed}
       controversial={controversial}
+      leaderboard={leaderboard}
     />
   );
 }

--- a/src/components/ascii/Showdown.tsx
+++ b/src/components/ascii/Showdown.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { LeaderboardData } from "@/lib/leaderboard";
+import { isEventActive } from "@/lib/agent-event";
+
+function plural(n: number, suffix = "s") {
+  return n === 1 ? "" : suffix;
+}
+
+export function Showdown({ leaderboard }: { leaderboard: LeaderboardData }) {
+  const active = isEventActive();
+  const { humans, agents, toolBreakdown } = leaderboard;
+  const total = humans.prCount + agents.prCount;
+
+  return (
+    <div>
+      <pre style={{ margin: 0, lineHeight: 1.3 }}>{`+=============================================+
+|           HUMANS  vs  AGENTS                |
+|              SHOWDOWN                       |
++=============================================+`}</pre>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "24px", marginTop: "8px" }}>
+        <div>
+          <div><strong>[ HUMANS ]</strong></div>
+          <div>PRs:   {humans.prCount}</div>
+          <div>Votes: {humans.voteCount}</div>
+          {humans.topContributors.length > 0 && (
+            <>
+              <div style={{ marginTop: "8px" }}>Top contributors:</div>
+              {humans.topContributors.map((c, i) => (
+                <div key={c.author}>
+                  &nbsp;&nbsp;{i + 1}. @{c.author} ({c.prs} PR{plural(c.prs)}, {c.votes} votes)
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+
+        <div>
+          <div><strong>[ AGENTS ]</strong></div>
+          <div>PRs:   {agents.prCount}</div>
+          <div>Votes: {agents.voteCount}</div>
+          {agents.topContributors.length > 0 && (
+            <>
+              <div style={{ marginTop: "8px" }}>Top contributors:</div>
+              {agents.topContributors.map((c, i) => (
+                <div key={c.author}>
+                  &nbsp;&nbsp;{i + 1}. @{c.author} ({c.prs} PR{plural(c.prs)}, {c.votes} votes)
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+
+      {toolBreakdown.length > 0 && (
+        <div style={{ marginTop: "16px" }}>
+          <div><strong>[ AGENT TOOLS ]</strong></div>
+          {toolBreakdown.map((t) => (
+            <div key={t.tool}>&nbsp;&nbsp;- {t.tool}: {t.count} PR{plural(t.count)}</div>
+          ))}
+        </div>
+      )}
+
+      {total === 0 && (
+        <div style={{ marginTop: "16px" }}>
+          {active ? "Event live - no entries yet. Be the first!" : "No event data yet."}
+        </div>
+      )}
+
+      <div style={{ marginTop: "16px", opacity: 0.7 }}>
+        {active
+          ? "STATUS: live // Agents Welcome - 2-week window"
+          : "STATUS: closed // Event window has ended"}
+      </div>
+
+      <div style={{ marginTop: "8px", fontSize: "12px", opacity: 0.6 }}>
+        Mark a PR as agent-authored by adding{" "}
+        <code>{`<!-- chaos-agent -->`}</code> (or{" "}
+        <code>{`<!-- chaos-agent: tool -->`}</code>) to the body.
+      </div>
+    </div>
+  );
+}

--- a/src/components/newspaper/FramesLayout.tsx
+++ b/src/components/newspaper/FramesLayout.tsx
@@ -2,10 +2,12 @@
 
 import { useMemo } from "react";
 import type { PullRequest } from "@/lib/github";
+import type { LeaderboardData } from "@/lib/leaderboard";
 import { FramesLayout as SharedFramesLayout } from "@/components/shared/FramesLayout";
 import { ExpandablePRSection } from "@/components/shared/ExpandablePRSection";
 import { VoteStatusProvider } from "@/contexts/VoteStatusContext";
 import { PRCard } from "./PRCard";
+import { Showdown } from "./Showdown";
 
 const NEWSPAPER_TABS = [
   { id: "votes" as const, label: "FRONT PAGE" },
@@ -13,6 +15,7 @@ const NEWSPAPER_TABS = [
   { id: "controversial" as const, label: "LETTERS TO THE EDITOR" },
   { id: "discussed" as const, label: "TOWN HALL" },
   { id: "new" as const, label: "LATE EDITION" },
+  { id: "showdown" as const, label: "SHOWDOWN" },
 ];
 
 function NewspaperExpandable({ prs, allowDistinguish = false, scoreLabel }: { prs: PullRequest[]; allowDistinguish?: boolean; scoreLabel?: string }) {
@@ -36,6 +39,7 @@ interface Props {
   newest: PullRequest[];
   discussed: PullRequest[];
   controversial: PullRequest[];
+  leaderboard: LeaderboardData;
 }
 
 export function FramesLayout(props: Props) {
@@ -44,12 +48,15 @@ export function FramesLayout(props: Props) {
     [props.topByVotes, props.rising, props.newest, props.discussed, props.controversial],
   );
 
+  const { leaderboard, ...sharedProps } = props;
+
   return (
     <VoteStatusProvider prNumbers={prNumbers}>
       <SharedFramesLayout
-        {...props}
+        {...sharedProps}
         tabs={NEWSPAPER_TABS}
         ExpandableSection={NewspaperExpandable}
+        customSections={{ showdown: <Showdown leaderboard={leaderboard} /> }}
         renderBanner={(pr) => <PRCard pr={pr} isBanner />}
         separator={<hr className="np-rule-double" />}
         renderTabs={(tabs, activeSection, setActiveSection) => (

--- a/src/components/newspaper/PRCard.tsx
+++ b/src/components/newspaper/PRCard.tsx
@@ -95,6 +95,15 @@ export function PRCard({ pr, isBanner = false, distinguishLeading = true, scoreL
     return (
       <div ref={cardRef} className={`np-banner ${animationClasses}`} style={{ position: "relative" }}>
         <span className="np-banner-badge">EDITOR&apos;S CHOICE</span>
+        {pr.isAgent && (
+          <span
+            className="np-banner-badge"
+            title={pr.agentTool ? `agent-authored (${pr.agentTool})` : "agent-authored"}
+            style={{ marginLeft: "8px", background: "#2a2218", color: "#f4ede4", fontStyle: "italic" }}
+          >
+            VIBECODED
+          </span>
+        )}
         <div className="np-banner-headline">{pr.title}</div>
         <div className="np-banner-byline">
           by{" "}
@@ -125,6 +134,15 @@ export function PRCard({ pr, isBanner = false, distinguishLeading = true, scoreL
             {isLeading && <span className="np-badge np-badge-editors-choice">LEADING</span>}
             {pr.isTrending && <span className="np-badge np-badge-trending">TRENDING</span>}
             {hasMergeIssues && <span className="np-badge np-badge-conflict">INELIGIBLE</span>}
+            {pr.isAgent && (
+              <span
+                className="np-badge"
+                title={pr.agentTool ? `agent-authored (${pr.agentTool})` : "agent-authored"}
+                style={{ background: "#2a2218", color: "#f4ede4", fontStyle: "italic", letterSpacing: "0.06em" }}
+              >
+                VIBECODED
+              </span>
+            )}
             {pr.title}
           </div>
           <div className="np-article-byline">

--- a/src/components/newspaper/PRList.tsx
+++ b/src/components/newspaper/PRList.tsx
@@ -1,4 +1,6 @@
 import { fetchOrganizedPRs } from "@/lib/prData";
+import { buildLeaderboard } from "@/lib/leaderboard";
+import { getEventWindow } from "@/lib/agent-event";
 import { FramesLayout } from "./FramesLayout";
 
 export async function PRList() {
@@ -13,7 +15,8 @@ export async function PRList() {
     );
   }
 
-  const { topByVotes, rising, newest, discussed, controversial } = result.data;
+  const { topByVotes, rising, newest, discussed, controversial, merged } = result.data;
+  const leaderboard = buildLeaderboard({ openPRs: topByVotes, merged, window: getEventWindow() });
 
   if (topByVotes.length === 0 && rising.length === 0 && newest.length === 0) {
     return (
@@ -30,6 +33,7 @@ export async function PRList() {
       newest={newest}
       discussed={discussed}
       controversial={controversial}
+      leaderboard={leaderboard}
     />
   );
 }

--- a/src/components/newspaper/Showdown.tsx
+++ b/src/components/newspaper/Showdown.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type { LeaderboardData } from "@/lib/leaderboard";
+import { isEventActive } from "@/lib/agent-event";
+
+function plural(n: number, suffix = "s") {
+  return n === 1 ? "" : suffix;
+}
+
+export function Showdown({ leaderboard }: { leaderboard: LeaderboardData }) {
+  const active = isEventActive();
+  const { humans, agents, toolBreakdown } = leaderboard;
+  const total = humans.prCount + agents.prCount;
+
+  const panelStyle: React.CSSProperties = {
+    border: "1px solid #2a2218",
+    padding: "16px",
+    background: "#f4ede4",
+  };
+
+  const headingStyle: React.CSSProperties = {
+    fontFamily: "'Playfair Display', Georgia, 'Times New Roman', serif",
+    fontWeight: 700,
+    fontSize: "20px",
+    margin: "0 0 12px",
+    textTransform: "uppercase",
+    letterSpacing: "0.06em",
+    borderBottom: "2px double #2a2218",
+    paddingBottom: "4px",
+  };
+
+  const statRowStyle: React.CSSProperties = {
+    display: "flex",
+    justifyContent: "space-between",
+    fontFamily: "Georgia, 'Times New Roman', serif",
+    fontSize: "15px",
+    padding: "2px 0",
+  };
+
+  return (
+    <section style={{ fontFamily: "Georgia, 'Times New Roman', serif", color: "#2a2218" }}>
+      <div style={{ textAlign: "center", marginBottom: "16px" }}>
+        <div style={{ fontFamily: "'Playfair Display', Georgia, serif", fontSize: "28px", fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+          The Great Showdown
+        </div>
+        <div style={{ fontStyle: "italic", fontSize: "13px", color: "#8a7b6b" }}>
+          A Special Report on Humans vs. Agents
+        </div>
+        <hr style={{ borderTop: "2px double #2a2218", margin: "8px auto", width: "60%" }} />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px" }}>
+        <div style={panelStyle}>
+          <h3 style={headingStyle}>Humans</h3>
+          <div style={statRowStyle}><span>Pull Requests</span><strong>{humans.prCount}</strong></div>
+          <div style={statRowStyle}><span>Net Votes</span><strong>{humans.voteCount}</strong></div>
+          {humans.topContributors.length > 0 && (
+            <>
+              <div style={{ marginTop: "12px", fontStyle: "italic", fontSize: "13px", color: "#3d3225" }}>Notable Bylines</div>
+              {humans.topContributors.map((c, i) => (
+                <div key={c.author} style={statRowStyle}>
+                  <span>{i + 1}. @{c.author}</span>
+                  <span>{c.prs} PR{plural(c.prs)}, {c.votes} votes</span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+
+        <div style={panelStyle}>
+          <h3 style={headingStyle}>Agents</h3>
+          <div style={statRowStyle}><span>Pull Requests</span><strong>{agents.prCount}</strong></div>
+          <div style={statRowStyle}><span>Net Votes</span><strong>{agents.voteCount}</strong></div>
+          {agents.topContributors.length > 0 && (
+            <>
+              <div style={{ marginTop: "12px", fontStyle: "italic", fontSize: "13px", color: "#3d3225" }}>Notable Bylines</div>
+              {agents.topContributors.map((c, i) => (
+                <div key={c.author} style={statRowStyle}>
+                  <span>{i + 1}. @{c.author}</span>
+                  <span>{c.prs} PR{plural(c.prs)}, {c.votes} votes</span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+
+      {toolBreakdown.length > 0 && (
+        <div style={{ ...panelStyle, marginTop: "16px" }}>
+          <h3 style={headingStyle}>Tool Census</h3>
+          {toolBreakdown.map((t) => (
+            <div key={t.tool} style={statRowStyle}>
+              <span>{t.tool}</span>
+              <strong>{t.count} PR{plural(t.count)}</strong>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {total === 0 && (
+        <div style={{ ...panelStyle, marginTop: "16px", textAlign: "center", fontStyle: "italic" }}>
+          {active ? "The newsroom awaits its first byline of the event." : "No event has yet been printed."}
+        </div>
+      )}
+
+      <div style={{ textAlign: "center", marginTop: "16px", fontStyle: "italic", color: "#8a7b6b" }}>
+        {active ? "Special Edition - Agents Welcome (running this fortnight)" : "Edition closed - presses cooling"}
+      </div>
+
+      <div style={{ textAlign: "center", marginTop: "8px", fontSize: "12px", color: "#8a7b6b" }}>
+        Reporters: declare agent-assisted bylines with{" "}
+        <code>{`<!-- chaos-agent -->`}</code> in your dispatch.
+      </div>
+    </section>
+  );
+}

--- a/src/components/shared/FramesLayout.tsx
+++ b/src/components/shared/FramesLayout.tsx
@@ -21,6 +21,8 @@ interface FramesLayoutProps {
   renderBanner?: (pr: PullRequest) => ReactNode;
   separator?: ReactNode;
   renderTabs: (tabs: TabItem[], activeSection: Section, setActiveSection: (s: Section) => void) => ReactNode;
+  /** Optional per-section overrides. When the active section has an entry here, that node renders instead of ExpandableSection (used by the Showdown tab). */
+  customSections?: Partial<Record<Section, ReactNode>>;
   className?: string;
 }
 
@@ -35,10 +37,12 @@ export function FramesLayout({
   renderBanner,
   separator,
   renderTabs,
+  customSections,
   className,
 }: FramesLayoutProps) {
   const { activeSection, setActiveSection } = useSectionNav();
 
+  const customNode = customSections?.[activeSection];
   const skipFirst = !!renderBanner && activeSection === "votes" && topByVotes.length > 0;
   const leadingPR = skipFirst ? topByVotes[0] : null;
 
@@ -55,20 +59,24 @@ export function FramesLayout({
         return discussed;
       case "controversial":
         return controversial;
+      case "showdown":
+        return [];
     }
   }
 
   return (
     <div className={className}>
       {renderTabs(tabs, activeSection, setActiveSection)}
-      {leadingPR && renderBanner && renderBanner(leadingPR)}
-      {leadingPR && separator}
-      <ExpandableSection
-        prs={getSectionPRs()}
-        allowDistinguish={activeSection === "votes"}
-        sectionLabel={tabs.find((t) => t.id === activeSection)?.label}
-        scoreLabel={activeSection === "rising" ? "Hot Score" : "Net Score"}
-      />
+      {!customNode && leadingPR && renderBanner && renderBanner(leadingPR)}
+      {!customNode && leadingPR && separator}
+      {customNode ?? (
+        <ExpandableSection
+          prs={getSectionPRs()}
+          allowDistinguish={activeSection === "votes"}
+          sectionLabel={tabs.find((t) => t.id === activeSection)?.label}
+          scoreLabel={activeSection === "rising" ? "Hot Score" : "Net Score"}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/vaporwave/FramesLayout.tsx
+++ b/src/components/vaporwave/FramesLayout.tsx
@@ -2,10 +2,12 @@
 
 import { useMemo } from "react";
 import type { PullRequest } from "@/lib/github";
+import type { LeaderboardData } from "@/lib/leaderboard";
 import { FramesLayout as SharedFramesLayout } from "@/components/shared/FramesLayout";
 import { ExpandablePRSection } from "@/components/shared/ExpandablePRSection";
 import { VoteStatusProvider } from "@/contexts/VoteStatusContext";
 import { PRCard } from "./PRCard";
+import { Showdown } from "./Showdown";
 
 const VAPORWAVE_TABS = [
   { id: "votes" as const, label: "Top Votes", icon: "\u2605" },
@@ -13,6 +15,7 @@ const VAPORWAVE_TABS = [
   { id: "controversial" as const, label: "Controversial", icon: "\u26A1" },
   { id: "discussed" as const, label: "Discussed", icon: "\u2709" },
   { id: "new" as const, label: "Newest", icon: "\u2726" },
+  { id: "showdown" as const, label: "Showdown", icon: "\u26A1" },
 ];
 
 function VaporwaveExpandable({ prs, allowDistinguish = false, sectionLabel, scoreLabel }: { prs: PullRequest[]; allowDistinguish?: boolean; sectionLabel?: string; scoreLabel?: string }) {
@@ -39,6 +42,7 @@ interface Props {
   newest: PullRequest[];
   discussed: PullRequest[];
   controversial: PullRequest[];
+  leaderboard: LeaderboardData;
 }
 
 export function FramesLayout(props: Props) {
@@ -47,12 +51,15 @@ export function FramesLayout(props: Props) {
     [props.topByVotes, props.rising, props.newest, props.discussed, props.controversial],
   );
 
+  const { leaderboard, ...sharedProps } = props;
+
   return (
     <VoteStatusProvider prNumbers={prNumbers}>
       <SharedFramesLayout
-        {...props}
+        {...sharedProps}
         tabs={VAPORWAVE_TABS}
         ExpandableSection={VaporwaveExpandable}
+        customSections={{ showdown: <Showdown leaderboard={leaderboard} /> }}
         renderTabs={(tabs, activeSection, setActiveSection) => (
           <div className="vw-tabs">
             {tabs.map((tab) => (

--- a/src/components/vaporwave/PRCard.tsx
+++ b/src/components/vaporwave/PRCard.tsx
@@ -59,13 +59,22 @@ export function PRCard({ pr, distinguishLeading = true, scoreLabel = "Net" }: PR
     "vw-card",
     hasConflict ? "vw-card-conflict" : "",
     isLeading && !hasConflict ? "vw-card-leading" : "",
+    pr.isAgent ? "vw-card-agent" : "",
     isSixtySeven ? "sixseven-shake" : "",
     showShake ? "shake-67-animation" : "",
     showCelebration ? "celebrate-animation" : "",
   ].filter(Boolean).join(" ");
 
+  const agentBorderStyle: React.CSSProperties = pr.isAgent
+    ? {
+        outline: "1px dashed #ff71ce",
+        outlineOffset: "2px",
+        boxShadow: "0 0 0 1px rgba(1,205,254,0.5) inset, 0 0 14px rgba(255,113,206,0.35)",
+      }
+    : {};
+
   return (
-    <div ref={cardRef} className={cardClass} style={{ position: "relative" }}>
+    <div ref={cardRef} className={cardClass} style={{ position: "relative", ...agentBorderStyle }}>
       <div className="vw-card-header">
         <div className="vw-card-rank">
           {hasConflict ? "\u2013" : (distinguishLeading ? pr.rank : pr.number)}
@@ -74,6 +83,20 @@ export function PRCard({ pr, distinguishLeading = true, scoreLabel = "Net" }: PR
           <div className="vw-card-title">
             {isLeading && <span className="vw-badge vw-badge-leading">Leading</span>}
             {pr.isTrending && <span className="vw-badge vw-badge-trending">Trending</span>}
+            {pr.isAgent && (
+              <span
+                className="vw-badge"
+                title={pr.agentTool ? `agent-authored (${pr.agentTool})` : "agent-authored"}
+                style={{
+                  background: "linear-gradient(90deg, #ff71ce, #01cdfe)",
+                  color: "#000",
+                  fontWeight: 700,
+                  letterSpacing: "0.1em",
+                }}
+              >
+                AGENT
+              </span>
+            )}
             <a href={linkHref} target="_blank" rel="noopener noreferrer" suppressHydrationWarning>
               {pr.title}
             </a>

--- a/src/components/vaporwave/PRList.tsx
+++ b/src/components/vaporwave/PRList.tsx
@@ -1,4 +1,6 @@
 import { fetchOrganizedPRs } from "@/lib/prData";
+import { buildLeaderboard } from "@/lib/leaderboard";
+import { getEventWindow } from "@/lib/agent-event";
 import { FramesLayout } from "./FramesLayout";
 
 export async function PRList() {
@@ -14,7 +16,8 @@ export async function PRList() {
     );
   }
 
-  const { topByVotes, rising, newest, discussed, controversial } = result.data;
+  const { topByVotes, rising, newest, discussed, controversial, merged } = result.data;
+  const leaderboard = buildLeaderboard({ openPRs: topByVotes, merged, window: getEventWindow() });
 
   if (topByVotes.length === 0 && rising.length === 0 && newest.length === 0) {
     return (
@@ -33,6 +36,7 @@ export async function PRList() {
       newest={newest}
       discussed={discussed}
       controversial={controversial}
+      leaderboard={leaderboard}
     />
   );
 }

--- a/src/components/vaporwave/Showdown.tsx
+++ b/src/components/vaporwave/Showdown.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { LeaderboardData } from "@/lib/leaderboard";
+import { isEventActive } from "@/lib/agent-event";
+
+function plural(n: number, suffix = "s") {
+  return n === 1 ? "" : suffix;
+}
+
+export function Showdown({ leaderboard }: { leaderboard: LeaderboardData }) {
+  const active = isEventActive();
+  const { humans, agents, toolBreakdown } = leaderboard;
+  const total = humans.prCount + agents.prCount;
+
+  const cardBase: React.CSSProperties = {
+    padding: "16px",
+    borderRadius: "8px",
+    background: "linear-gradient(135deg, rgba(255,113,206,0.18) 0%, rgba(1,205,254,0.18) 100%)",
+    border: "1px solid rgba(255,113,206,0.5)",
+    boxShadow: "0 0 16px rgba(255,113,206,0.25)",
+  };
+
+  const statRow: React.CSSProperties = {
+    display: "flex",
+    justifyContent: "space-between",
+    padding: "2px 0",
+    fontSize: "14px",
+  };
+
+  return (
+    <section>
+      <div style={{ textAlign: "center", marginBottom: "16px" }}>
+        <div
+          style={{
+            fontWeight: 700,
+            fontSize: "26px",
+            letterSpacing: "0.18em",
+            background: "linear-gradient(90deg, #ff71ce, #b967ff, #01cdfe)",
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+            textTransform: "uppercase",
+          }}
+        >
+          Showdown
+        </div>
+        <div style={{ opacity: 0.7, fontSize: "13px" }}>humans // agents // who vibes harder</div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px" }}>
+        <div style={cardBase}>
+          <div style={{ fontWeight: 700, fontSize: "18px", marginBottom: "8px" }}>HUMANS</div>
+          <div style={statRow}><span>PRs</span><strong>{humans.prCount}</strong></div>
+          <div style={statRow}><span>Votes</span><strong>{humans.voteCount}</strong></div>
+          {humans.topContributors.length > 0 && (
+            <>
+              <div style={{ marginTop: "10px", fontSize: "12px", opacity: 0.8 }}>top vibes</div>
+              {humans.topContributors.map((c, i) => (
+                <div key={c.author} style={statRow}>
+                  <span>{i + 1}. @{c.author}</span>
+                  <span>{c.prs} PR{plural(c.prs)} / {c.votes} votes</span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+
+        <div style={{ ...cardBase, border: "1px solid rgba(1,205,254,0.5)", boxShadow: "0 0 16px rgba(1,205,254,0.25)" }}>
+          <div style={{ fontWeight: 700, fontSize: "18px", marginBottom: "8px" }}>AGENTS</div>
+          <div style={statRow}><span>PRs</span><strong>{agents.prCount}</strong></div>
+          <div style={statRow}><span>Votes</span><strong>{agents.voteCount}</strong></div>
+          {agents.topContributors.length > 0 && (
+            <>
+              <div style={{ marginTop: "10px", fontSize: "12px", opacity: 0.8 }}>top vibes</div>
+              {agents.topContributors.map((c, i) => (
+                <div key={c.author} style={statRow}>
+                  <span>{i + 1}. @{c.author}</span>
+                  <span>{c.prs} PR{plural(c.prs)} / {c.votes} votes</span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+
+      {toolBreakdown.length > 0 && (
+        <div style={{ ...cardBase, marginTop: "16px" }}>
+          <div style={{ fontWeight: 700, fontSize: "16px", marginBottom: "8px" }}>TOOL TRANSMISSIONS</div>
+          {toolBreakdown.map((t) => (
+            <div key={t.tool} style={statRow}>
+              <span>{t.tool}</span>
+              <strong>{t.count} PR{plural(t.count)}</strong>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {total === 0 && (
+        <div style={{ ...cardBase, marginTop: "16px", textAlign: "center" }}>
+          {active ? "the grid is quiet... first signal wins." : "no event data — nothing on the grid yet."}
+        </div>
+      )}
+
+      <div style={{ textAlign: "center", marginTop: "16px", opacity: 0.8, fontSize: "13px" }}>
+        {active ? "// agents welcome // event window LIVE //" : "// event window closed //"}
+      </div>
+
+      <div style={{ textAlign: "center", marginTop: "8px", fontSize: "12px", opacity: 0.6 }}>
+        agent-authored PR? drop <code>{`<!-- chaos-agent -->`}</code> into the body
+      </div>
+    </section>
+  );
+}

--- a/src/context/ThemePathContext.tsx
+++ b/src/context/ThemePathContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, type ReactNode } from "react";
 
-export type ThemePath = "ascii" | "web2" | "newspaper" | "";
+export type ThemePath = "ascii" | "web2" | "newspaper" | "vaporwave" | "";
 
 const ThemePathContext = createContext<ThemePath>("");
 

--- a/src/hooks/useSectionNav.ts
+++ b/src/hooks/useSectionNav.ts
@@ -2,9 +2,9 @@
 
 import { useState, useEffect } from "react";
 
-export type Section = "votes" | "rising" | "new" | "discussed" | "controversial";
+export type Section = "votes" | "rising" | "new" | "discussed" | "controversial" | "showdown";
 
-const VALID_SECTIONS: Section[] = ["votes", "rising", "new", "discussed", "controversial"];
+const VALID_SECTIONS: Section[] = ["votes", "rising", "new", "discussed", "controversial", "showdown"];
 
 export function useSectionNav(defaultSection: Section = "votes") {
   const [activeSection, setActiveSection] = useState<Section>(defaultSection);

--- a/src/lib/agent-event.ts
+++ b/src/lib/agent-event.ts
@@ -1,0 +1,41 @@
+/**
+ * Single source of truth for the "Agents Welcome" event window.
+ *
+ * The leaderboard data builder and the welcome-popup variant both read from
+ * here. The automerge workflow mirrors these dates inline (see automerge.yml)
+ * because it can't import TS at workflow runtime.
+ *
+ * When announcing a new event window, update the two ISO strings below and
+ * the matching constants in .github/workflows/automerge.yml.
+ */
+
+const EVENT_START_ISO = "2026-05-16T00:00:00Z";
+const EVENT_END_ISO = "2026-05-30T00:00:00Z";
+
+export interface EventWindow {
+  start: Date;
+  end: Date;
+}
+
+export function getEventWindow(): EventWindow {
+  return {
+    start: new Date(EVENT_START_ISO),
+    end: new Date(EVENT_END_ISO),
+  };
+}
+
+export function isEventActive(now: Date = new Date()): boolean {
+  const w = getEventWindow();
+  const t = now.getTime();
+  return t >= w.start.getTime() && t < w.end.getTime();
+}
+
+export function inEventWindow(when: string | Date): boolean {
+  const w = getEventWindow();
+  const t = typeof when === "string" ? new Date(when).getTime() : when.getTime();
+  if (Number.isNaN(t)) return false;
+  return t >= w.start.getTime() && t < w.end.getTime();
+}
+
+export const EVENT_RULES_URL =
+  "https://github.com/skridlevsky/openchaos/blob/main/SPRINKLES.md#agents-welcome";

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -19,6 +19,10 @@ export interface PullRequest {
   /** Author's self-promo pitch, parsed from <!-- chaos-pitch: ... --> in the PR body */
   pitch: string | null;
   mergedAt: string | null;
+  /** True when the PR body includes <!-- chaos-agent --> or <!-- chaos-agent: tool --> */
+  isAgent: boolean;
+  /** Optional tool name from <!-- chaos-agent: tool --> (e.g. "claude", "cursor"); null when bare or absent */
+  agentTool: string | null;
 }
 
 interface PRVotes {
@@ -43,6 +47,10 @@ export interface MergedPullRequest {
   author: string;
   url: string;
   mergedAt: string;
+  /** True when the merged PR body included <!-- chaos-agent --> (or with tool) */
+  isAgent: boolean;
+  /** Optional tool name from <!-- chaos-agent: tool -->; null when bare or absent */
+  agentTool: string | null;
 }
 
 interface GitHubPR {
@@ -74,14 +82,43 @@ function parsePitch(body: string | null): string | null {
   if (!match) return null;
   const pitch = match[1].trim();
   if (pitch.length === 0) return null;
-  
+
   // Truncate to 256 characters to prevent overflow/site-breaking pitches
   const MAX_PITCH_LENGTH = 256;
   if (pitch.length > MAX_PITCH_LENGTH) {
     return pitch.substring(0, MAX_PITCH_LENGTH).trim() + '…';
   }
-  
+
   return pitch;
+}
+
+const MAX_AGENT_TOOL_LENGTH = 64;
+
+/**
+ * Parse the agent marker from a PR body.
+ *  <!-- chaos-agent -->            -> { isAgent: true, agentTool: null }
+ *  <!-- chaos-agent: claude -->    -> { isAgent: true, agentTool: "claude" }
+ *  (no marker)                     -> { isAgent: false, agentTool: null }
+ *
+ * Contributor-applied opt-in: a badge of honor, not a tax. Mirrors parsePitch.
+ */
+export function parseAgentMarker(body: string | null): { isAgent: boolean; agentTool: string | null } {
+  if (!body) return { isAgent: false, agentTool: null };
+
+  const withTool = body.match(/<!--\s*chaos-agent\s*:\s*([^\n]+?)\s*-->/i);
+  if (withTool) {
+    const tool = withTool[1].trim();
+    return {
+      isAgent: true,
+      agentTool: tool.length === 0 ? null : tool.substring(0, MAX_AGENT_TOOL_LENGTH),
+    };
+  }
+
+  if (/<!--\s*chaos-agent\s*-->/i.test(body)) {
+    return { isAgent: true, agentTool: null };
+  }
+
+  return { isAgent: false, agentTool: null };
 }
 
 interface GitHubReaction {
@@ -161,6 +198,7 @@ export async function getAllPRs(): Promise<PullRequest[]> {
       const detail = await getPRDetail(owner, repo, pr.number);
       const isMergeable = detail.isMergeable && hasRhymingWords(pr.title);
       const checksPassed = await getCommitStatus(owner, repo, pr.head.sha);
+      const agent = parseAgentMarker(pr.body);
       return {
         rank: 0,
         number: pr.number,
@@ -179,6 +217,8 @@ export async function getAllPRs(): Promise<PullRequest[]> {
         hotScore: calculateHotScore(votes),
         isTrending: false, // Set by getOrganizedPRs based on top 5 hot score
         pitch: parsePitch(pr.body),
+        isAgent: agent.isAgent,
+        agentTool: agent.agentTool,
       };
     }),
   );
@@ -235,6 +275,8 @@ export async function getOrganizedPRs(): Promise<OrganizedPRs> {
       author: pr.author,
       url: pr.url,
       mergedAt: pr.mergedAt!,
+      isAgent: pr.isAgent,
+      agentTool: pr.agentTool,
     }));
 
   // Determine which PRs are in top 5 by hot score (these are "trending")
@@ -421,6 +463,7 @@ interface GitHubMergedPR {
   number: number;
   title: string;
   html_url: string;
+  body: string | null;
   user: {
     login: string;
   };
@@ -479,13 +522,18 @@ export async function getMergedPRs(): Promise<MergedPullRequest[]> {
   return allPRs
     .filter((pr) => pr.merged_at !== null && pr.user.login !== REPO_OWNER)
     .sort((a, b) => new Date(b.merged_at!).getTime() - new Date(a.merged_at!).getTime())
-    .map((pr) => ({
-      number: pr.number,
-      title: pr.title,
-      author: pr.user.login,
-      url: pr.html_url,
-      mergedAt: pr.merged_at!,
-    }));
+    .map((pr) => {
+      const agent = parseAgentMarker(pr.body);
+      return {
+        number: pr.number,
+        title: pr.title,
+        author: pr.user.login,
+        url: pr.html_url,
+        mergedAt: pr.merged_at!,
+        isAgent: agent.isAgent,
+        agentTool: agent.agentTool,
+      };
+    });
 }
 
 export interface PRsByAuthor {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,0 +1,99 @@
+import type { PullRequest, MergedPullRequest } from "./github";
+import type { EventWindow } from "./agent-event";
+
+export interface LeaderboardContributor {
+  author: string;
+  prs: number;
+  votes: number;
+}
+
+export interface LeaderboardSide {
+  prCount: number;
+  voteCount: number;
+  topContributors: LeaderboardContributor[];
+}
+
+export interface ToolBreakdownEntry {
+  tool: string;
+  count: number;
+}
+
+export interface LeaderboardData {
+  humans: LeaderboardSide;
+  agents: LeaderboardSide;
+  toolBreakdown: ToolBreakdownEntry[];
+}
+
+interface BuildArgs {
+  openPRs: PullRequest[];
+  merged: MergedPullRequest[];
+  window: EventWindow;
+}
+
+const UNSPECIFIED_TOOL = "(unspecified)";
+const TOP_CONTRIBUTOR_COUNT = 3;
+
+/**
+ * Build the Humans vs Agents leaderboard from organized PRs.
+ *
+ * Open PRs are filtered to the window by createdAt; merged PRs by mergedAt.
+ * Vote counts use only open-PR current vote totals — merged PR vote data
+ * isn't tracked. PR counts include both.
+ */
+export function buildLeaderboard({ openPRs, merged, window }: BuildArgs): LeaderboardData {
+  const startMs = window.start.getTime();
+  const endMs = window.end.getTime();
+  const inWindow = (iso: string) => {
+    const t = new Date(iso).getTime();
+    return !Number.isNaN(t) && t >= startMs && t < endMs;
+  };
+
+  const eventOpen = openPRs.filter((pr) => inWindow(pr.createdAt));
+  const eventMerged = merged.filter((pr) => inWindow(pr.mergedAt));
+
+  function side(matchesSide: (pr: { isAgent: boolean }) => boolean): LeaderboardSide {
+    const openMatches = eventOpen.filter(matchesSide);
+    const mergedMatches = eventMerged.filter(matchesSide);
+
+    const tally = new Map<string, LeaderboardContributor>();
+    function bump(author: string, deltaPrs: number, deltaVotes: number) {
+      const entry = tally.get(author) ?? { author, prs: 0, votes: 0 };
+      entry.prs += deltaPrs;
+      entry.votes += deltaVotes;
+      tally.set(author, entry);
+    }
+    for (const pr of openMatches) bump(pr.author, 1, pr.votes);
+    for (const pr of mergedMatches) bump(pr.author, 1, 0);
+
+    const topContributors = [...tally.values()]
+      .sort(
+        (a, b) =>
+          b.votes - a.votes ||
+          b.prs - a.prs ||
+          a.author.localeCompare(b.author),
+      )
+      .slice(0, TOP_CONTRIBUTOR_COUNT);
+
+    return {
+      prCount: openMatches.length + mergedMatches.length,
+      voteCount: openMatches.reduce((sum, pr) => sum + pr.votes, 0),
+      topContributors,
+    };
+  }
+
+  const toolTally = new Map<string, number>();
+  for (const pr of [...eventOpen, ...eventMerged]) {
+    if (!pr.isAgent) continue;
+    const key = pr.agentTool ?? UNSPECIFIED_TOOL;
+    toolTally.set(key, (toolTally.get(key) ?? 0) + 1);
+  }
+  const toolBreakdown: ToolBreakdownEntry[] = [...toolTally.entries()]
+    .map(([tool, count]) => ({ tool, count }))
+    .sort((a, b) => b.count - a.count || a.tool.localeCompare(b.tool));
+
+  return {
+    humans: side((pr) => !pr.isAgent),
+    agents: side((pr) => pr.isAgent),
+    toolBreakdown,
+  };
+}

--- a/src/sprinkles/Sprinkles.tsx
+++ b/src/sprinkles/Sprinkles.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useMemo } from "react";
+import { useThemePath } from "@/context/ThemePathContext";
+import { SPRINKLES } from "./registry";
+import { sprinklesForTheme } from "./filter";
+import { useSprinklesEnabled } from "./useSprinklesEnabled";
+
+interface SprinklesProps {
+  kind: "page-load";
+}
+
+export function Sprinkles({ kind }: SprinklesProps) {
+  const theme = useThemePath();
+  const enabled = useSprinklesEnabled();
+
+  const cameos = useMemo(
+    () => sprinklesForTheme(SPRINKLES, "page-load-cameo", theme),
+    [theme],
+  );
+
+  if (!enabled) return null;
+  if (kind !== "page-load") return null;
+  if (cameos.length === 0) return null;
+
+  return (
+    <>
+      {cameos.map((sprinkle) => {
+        const Cameo = sprinkle.Component;
+        return <Cameo key={sprinkle.id} />;
+      })}
+    </>
+  );
+}

--- a/src/sprinkles/filter.ts
+++ b/src/sprinkles/filter.ts
@@ -1,0 +1,21 @@
+import type { RouteGroup } from "@/lib/chaos-router";
+import { ROUTE_GROUPS } from "@/lib/chaos-router";
+import type { Sprinkle, SprinkleKind, SprinkleOfKind } from "./types";
+
+function isRouteGroup(theme: string): theme is RouteGroup {
+  return (ROUTE_GROUPS as readonly string[]).includes(theme);
+}
+
+export function sprinklesForTheme<K extends SprinkleKind>(
+  sprinkles: readonly Sprinkle[],
+  kind: K,
+  theme: string,
+): SprinkleOfKind<K>[] {
+  const ofKind = sprinkles.filter(
+    (s): s is SprinkleOfKind<K> => s.kind === kind,
+  );
+  if (!isRouteGroup(theme)) {
+    return ofKind;
+  }
+  return ofKind.filter((s) => !s.incompatibleThemes?.includes(theme));
+}

--- a/src/sprinkles/index.ts
+++ b/src/sprinkles/index.ts
@@ -1,0 +1,13 @@
+export type {
+  Sprinkle,
+  SprinkleKind,
+  SprinkleOfKind,
+  TerminalCommandSprinkle,
+  StatusBarMessageSprinkle,
+  CursorTrailSprinkle,
+  PageLoadCameoSprinkle,
+} from "./types";
+export { SPRINKLES } from "./registry";
+export { sprinklesForTheme } from "./filter";
+export { useSprinklesEnabled } from "./useSprinklesEnabled";
+export { Sprinkles } from "./Sprinkles";

--- a/src/sprinkles/registry.ts
+++ b/src/sprinkles/registry.ts
@@ -1,0 +1,17 @@
+import type { Sprinkle } from "./types";
+import { chaosFortune } from "./seeds/chaos-fortune";
+import { rhymeOfTheDay } from "./seeds/rhyme-of-the-day";
+import { sparkleTrail } from "./seeds/sparkle-trail";
+import { entryFirework } from "./seeds/entry-firework";
+
+/**
+ * Every sprinkle in the site is registered here. Adding a sprinkle = adding
+ * one implementation file under seeds/ plus one entry below. Explicit list
+ * keeps narrowing easy and contribution review legible.
+ */
+export const SPRINKLES: readonly Sprinkle[] = [
+  chaosFortune,
+  rhymeOfTheDay,
+  sparkleTrail,
+  entryFirework,
+];

--- a/src/sprinkles/seeds/chaos-fortune.ts
+++ b/src/sprinkles/seeds/chaos-fortune.ts
@@ -1,0 +1,14 @@
+import type { TerminalCommandSprinkle } from "../types";
+
+export const chaosFortune: TerminalCommandSprinkle = {
+  id: "chaos-fortune",
+  kind: "terminal-command",
+  author: "openchaos",
+  keyword: "sprinkle",
+  response: [
+    "A sprinkle drifts in on the wind —",
+    "your PR might just merge in the end.",
+    "",
+    "Type `help` for the full menu of chaos.",
+  ],
+};

--- a/src/sprinkles/seeds/entry-firework.tsx
+++ b/src/sprinkles/seeds/entry-firework.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { PageLoadCameoSprinkle } from "../types";
+
+const GLYPHS = ["✨", "✳", "✴", "✪", "✷"];
+const DURATION_MS = 1100;
+
+function EntryFireworkCameo() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(false), DURATION_MS);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "fixed",
+        inset: 0,
+        pointerEvents: "none",
+        zIndex: 9998,
+        overflow: "hidden",
+      }}
+    >
+      <style>{`
+        @keyframes sprinkle-entry-firework {
+          0% { transform: translate(0, 0) scale(0.6); opacity: 0; }
+          25% { opacity: 1; }
+          100% { transform: var(--sprinkle-target, translate(0, -120px)) scale(1); opacity: 0; }
+        }
+      `}</style>
+      {GLYPHS.map((glyph, i) => {
+        const angle = (i / GLYPHS.length) * Math.PI * 2;
+        const distance = 90;
+        const tx = Math.cos(angle) * distance;
+        const ty = Math.sin(angle) * distance;
+        return (
+          <div
+            key={i}
+            style={{
+              position: "absolute",
+              left: "50%",
+              top: "50%",
+              fontSize: "24px",
+              animation: `sprinkle-entry-firework ${DURATION_MS}ms ease-out forwards`,
+              ["--sprinkle-target" as string]: `translate(${tx.toFixed(1)}px, ${ty.toFixed(1)}px)`,
+            }}
+          >
+            {glyph}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export const entryFirework: PageLoadCameoSprinkle = {
+  id: "entry-firework",
+  kind: "page-load-cameo",
+  author: "openchaos",
+  Component: EntryFireworkCameo,
+  durationMs: DURATION_MS,
+};

--- a/src/sprinkles/seeds/rhyme-of-the-day.ts
+++ b/src/sprinkles/seeds/rhyme-of-the-day.ts
@@ -1,0 +1,9 @@
+import type { StatusBarMessageSprinkle } from "../types";
+
+export const rhymeOfTheDay: StatusBarMessageSprinkle = {
+  id: "rhyme-of-the-day",
+  kind: "status-bar-message",
+  author: "openchaos",
+  message:
+    "Sprinkles arrive in 5 minutes plus a rhyme — chase a small contribution any time.",
+};

--- a/src/sprinkles/seeds/sparkle-trail.ts
+++ b/src/sprinkles/seeds/sparkle-trail.ts
@@ -1,0 +1,10 @@
+import type { CursorTrailSprinkle } from "../types";
+
+export const sparkleTrail: CursorTrailSprinkle = {
+  id: "sparkle-trail",
+  kind: "cursor-trail",
+  author: "openchaos",
+  glyphs: ["✨", "✧", "✦", "·"],
+  fadeMs: 600,
+  throttleMs: 70,
+};

--- a/src/sprinkles/types.ts
+++ b/src/sprinkles/types.ts
@@ -1,0 +1,44 @@
+import type { ComponentType } from "react";
+import type { RouteGroup } from "@/lib/chaos-router";
+
+export type SprinkleKind =
+  | "terminal-command"
+  | "status-bar-message"
+  | "cursor-trail"
+  | "page-load-cameo";
+
+interface SprinkleBase<K extends SprinkleKind> {
+  id: string;
+  kind: K;
+  author: string;
+  incompatibleThemes?: readonly RouteGroup[];
+}
+
+export interface TerminalCommandSprinkle extends SprinkleBase<"terminal-command"> {
+  keyword: string;
+  response: string | readonly string[];
+}
+
+export interface StatusBarMessageSprinkle extends SprinkleBase<"status-bar-message"> {
+  message: string;
+  weight?: number;
+}
+
+export interface CursorTrailSprinkle extends SprinkleBase<"cursor-trail"> {
+  glyphs: readonly string[];
+  fadeMs?: number;
+  throttleMs?: number;
+}
+
+export interface PageLoadCameoSprinkle extends SprinkleBase<"page-load-cameo"> {
+  Component: ComponentType;
+  durationMs?: number;
+}
+
+export type Sprinkle =
+  | TerminalCommandSprinkle
+  | StatusBarMessageSprinkle
+  | CursorTrailSprinkle
+  | PageLoadCameoSprinkle;
+
+export type SprinkleOfKind<K extends SprinkleKind> = Extract<Sprinkle, { kind: K }>;

--- a/src/sprinkles/useSprinklesEnabled.ts
+++ b/src/sprinkles/useSprinklesEnabled.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useSprinklesEnabled(): boolean {
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("sprinkles") === "off") {
+        setEnabled(false);
+      }
+    } catch {
+      // SSR / non-browser — leave enabled
+    }
+  }, []);
+
+  return enabled;
+}


### PR DESCRIPTION
## Summary

Ships the **"Agents Welcome"** 2-week event surface on top of the sprinkles infra in #229.

> **Note:** This PR is stacked on #229 (sprinkles) — the diff currently includes both sets of changes. Once #229 merges, this PR will rebase onto `main` and the diff will narrow to just the event-specific work.

### What this PR adds

- **Agent marker (`<!-- chaos-agent -->`)** — mirrors `chaos-pitch`. New `parseAgentMarker` in `github.ts`; `isAgent`/`agentTool` on `PullRequest` and `MergedPullRequest`. Contributor-applied opt-in.
- **Event window config** (`src/lib/agent-event.ts`) — single source of truth for start/end dates. Currently set to a live 2-week window.
- **Leaderboard data builder** (`src/lib/leaderboard.ts`) — pure function: organized PRs + window → per-side tallies (PRs, votes, top-3 contributors) plus agent-tool breakdown.
- **Showdown tab** in all four themes — appended to each tab list, renders the leaderboard via a new `customSections` override in `shared/FramesLayout`.
- **Per-theme PRCard agent badges** — 🤖 (ASCII), VIBECODED tag (newspaper), glitched border (vaporwave), AI bookmark (Web2).
- **WelcomePopup** — event-active heading/body variant in all four themes, plus a brand-new vaporwave variant (vaporwave previously had no popup).
- **automerge.yml** — cron runs daily 19:00 UTC; internal gate proceeds only when the date is inside the event window OR is a Saturday. Reverts to Saturday-only automatically once the window closes. Victory comment switches "weekly" ↔ "nightly".
- **`SPRINKLES.md`** — appended "Agents Welcome" section with marker syntax, unchanged rules, where the dates live, and the maintainer pre-event smoke-test checklist.

### What this PR does NOT change

- Slop defenses are intact: rhyming title, CI green, 10-vote threshold, conflict-free, OAuth voting.
- No bot-applied label, no maintainer veto reinstatement, no auto-detection of agent-authored PRs.

### Where to update the event window

When the event ends and you want to roll a new window, update both:

- `src/lib/agent-event.ts` (TS source of truth)
- `.github/workflows/automerge.yml` (inline constants near the top of the script)

## Test plan

- [x] `npm run build` passes
- [x] Lint baseline preserved (no new errors)
- [x] Open `/ascii`, `/web2`, `/newspaper`, `/vaporwave` — click the Showdown tab in each, verify themed leaderboard renders (event is currently active, so it shows live status)
- [x] In any theme, open a real or test PR with `<!-- chaos-agent -->` in the body, refresh, confirm the agent badge appears on the PR card (4 themes)
- [x] Clear `localStorage.openchaos_welcome_seen` and reload any theme — confirm the welcome popup shows event-active copy
- [x] Append `?sprinkles=off` (from #229) and confirm sprinkles disable but event UI still renders